### PR TITLE
allow users to choose workingdir under git cloned dir

### DIFF
--- a/charts/oxy-app/CONFIGURATION.md
+++ b/charts/oxy-app/CONFIGURATION.md
@@ -76,6 +76,7 @@ A Helm chart for Oxy application deployment on kubernetes
 | gitSync.repository | string | `""` |  |
 | gitSync.root | string | `""` |  |
 | gitSync.sshSecretName | string | `"oxy-git-ssh"` |  |
+| gitSync.workingDir | string | `""` |  |
 | headlessService.enabled | bool | `true` |  |
 | httpAuth.password | string | `""` |  |
 | httpAuth.passwordKey | string | `"password"` |  |

--- a/charts/oxy-app/Chart.yaml
+++ b/charts/oxy-app/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: oxy-app
 description: A Helm chart for Oxy application deployment on kubernetes
 type: application
-version: 0.3.3
-appVersion: "0.4.4"
+version: 0.3.4
+appVersion: "0.4.5"
 keywords:
   - oxy
 maintainers:

--- a/charts/oxy-app/templates/statefulset.yaml
+++ b/charts/oxy-app/templates/statefulset.yaml
@@ -12,6 +12,10 @@ are always appended to the persistence.mountPath, preventing accidental misconfi
 {{- $gitLinkDir := default "current" .Values.gitSync.link -}}
 {{- $gitRoot := printf "%s/%s" .Values.persistence.mountPath $gitRootDir -}}
 {{- $gitLink := printf "%s/%s" .Values.persistence.mountPath $gitLinkDir -}}
+{{- $workingDir := $gitLink -}}
+{{- if and .Values.gitSync.workingDir (ne .Values.gitSync.workingDir "") -}}
+  {{- $workingDir = printf "%s/%s" $gitLink .Values.gitSync.workingDir -}}
+{{- end -}}
 
 apiVersion: apps/v1
 kind: StatefulSet
@@ -214,7 +218,7 @@ spec:
               exec oxy serve{{- if not .Values.gitSync.enabled }} --cloud{{- end }}
           {{- end }}
           {{- if .Values.gitSync.enabled }}
-          workingDir: {{ $gitLink }}
+          workingDir: {{ $workingDir }}
           {{- end }}
           ports:
             - containerPort: {{ .Values.app.port }}
@@ -424,7 +428,7 @@ spec:
         - name: semantic-engine
           image: "{{ .Values.semanticEngine.image }}:{{ default (default .Chart.AppVersion .Values.app.imageTag) .Values.semanticEngine.imageTag }}"
           imagePullPolicy: {{ .Values.semanticEngine.imagePullPolicy }}
-          workingDir: {{ $gitLink }}
+          workingDir: {{ $workingDir }}
           ports:
             - containerPort: 4000
               protocol: TCP

--- a/charts/oxy-app/test-values/with-git-sync-values.yaml
+++ b/charts/oxy-app/test-values/with-git-sync-values.yaml
@@ -9,6 +9,10 @@ gitSync:
   period: 30s
   # The secret name where SSH keys are stored (defaults to oxy-git-ssh if not specified)
   sshSecretName: oxy-git-ssh
+  # Optional: Set a subdirectory within the cloned repo as the working directory
+  # Example: workingDir: "backend" will set workingDir to /workspace/current/backend
+  # Leave empty to use the root of the cloned repository
+  workingDir: ""
 
 # SSH Key configuration
 # IMPORTANT: For production, DO NOT store SSH keys in values.yaml!

--- a/charts/oxy-app/tests/statefulset_test.yaml
+++ b/charts/oxy-app/tests/statefulset_test.yaml
@@ -50,7 +50,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/oxy-hq/oxy:0.4.4"
+          value: "ghcr.io/oxy-hq/oxy:0.4.5"
       - contains:
           path: spec.template.spec.containers[0].ports
           content:

--- a/charts/oxy-app/values.yaml
+++ b/charts/oxy-app/values.yaml
@@ -186,6 +186,12 @@ gitSync:
   # Link directory name (not absolute path) for the symlink pointing to the latest synced
   # revision. Will be appended to persistence.mountPath. Defaults to "current" -> /workspace/current
   link: ""
+  # Working directory subdirectory (optional). When set, this subdirectory path will be
+  # appended to the git link directory to set as the container's workingDir.
+  # For example, if workingDir: "backend", the final working directory will be:
+  # /workspace/current/backend (assuming default link and mountPath values)
+  # Leave empty to use the root of the cloned repository.
+  workingDir: ""
   # Image pull policy for the git-sync init container. Valid values: Always, IfNotPresent, Never
   imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
How It Works:
When gitSync.workingDir is not set or empty → uses /workspace/current (the git link root)
When gitSync.workingDir: "backend" → uses /workspace/current/backend
When gitSync.workingDir: "services/api" → uses /workspace/current/services/api
