### PR TITLE
feat(oxy-app): standalone worker fleet (oxy worker) support

### DIFF
--- a/charts/oxy-app/Chart.yaml
+++ b/charts/oxy-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oxy-app
 description: A Helm chart for Oxy application deployment on kubernetes
 type: application
-version: 0.4.10
+version: 0.5.0
 appVersion: "0.5.49"
 keywords:
   - oxy

--- a/charts/oxy-app/Chart.yaml
+++ b/charts/oxy-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oxy-app
 description: A Helm chart for Oxy application deployment on kubernetes
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "0.5.49"
 keywords:
   - oxy

--- a/charts/oxy-app/README.md
+++ b/charts/oxy-app/README.md
@@ -70,6 +70,16 @@ This doc tries to focus only on chart-specific, differential behavior you won't 
 - External secrets
   - `externalSecrets.envSecretNames` copies secret keys & values as env vars
   - `externalSecrets.fileSecrets` copies secret keys as files into the workspace.
+- Standalone worker fleet (`oxy worker`)
+  - Opt-in: set `worker.enabled: true` to render a separate Deployment
+    that drains the `agentic_task_queue` table out-of-process. Pair with
+    `appServer.disableInprocessWorkers: true` on the HTTP StatefulSet so
+    only one fleet is draining the queue.
+  - Off by default, so existing deployments are unaffected on upgrade.
+  - See [docs/worker-fleet.md](docs/worker-fleet.md) for the topology,
+    HPA wiring (Prometheus + queue-depth custom metric), and the
+    `--skip-migrations` rationale. Background design lives in
+    oxy-hq/oxygen-internal#2409.
 
 ## Validation & Testing
 

--- a/charts/oxy-app/docs/worker-fleet.md
+++ b/charts/oxy-app/docs/worker-fleet.md
@@ -1,0 +1,152 @@
+# Standalone Worker Fleet
+
+Run Oxy's durable orchestrator as a separate Deployment so HTTP frontends
+and queue workers scale independently.
+
+Background and protocol design live in the oxygen-internal repo:
+
+- PR oxy-hq/oxygen-internal#2409 (`feat/worker-fleet-separation`)
+- `internal-docs/worker-fleet.md` on the same branch — the canonical
+  dev/operator guide
+
+The chart pieces below mirror that guide; if the two disagree, the
+oxygen-internal doc wins.
+
+## When to enable
+
+| Mode | Chart config | Use when |
+| --- | --- | --- |
+| Single-process | `worker.enabled: false` (default) | Local dev, single-node prod. HTTP and workers share one StatefulSet pod. |
+| Split fleet | `worker.enabled: true` + `appServer.disableInprocessWorkers: true` | Production where HTTP and worker scaling signals diverge (request rate vs queue depth), or where you want different node pools / rollout cadences for each. |
+
+Both deployments must point at the **same Postgres**. The durable queue
+(`agentic_task_queue`) is the only coordination surface.
+
+## Topology
+
+```
++--------------------+         +--------------------+
+| oxy serve          |         | oxy worker         |
+| --no-workers       |         | --health-port 8081 |
+| (StatefulSet)      |         | (Deployment xN)    |
+|                    |         |                    |
+|  HTTP frontend     |         |  Drains queue via  |
+|  + PostgresRouter  |         |  SKIP LOCKED       |
++---------+----------+         +---------+----------+
+          |                              |
+          +----------+ Postgres +--------+
+                     |
+              agentic_task_queue
+```
+
+## Enabling
+
+Minimal turn-on:
+
+```yaml
+appServer:
+  disableInprocessWorkers: true   # HTTP fleet stops draining the queue
+
+worker:
+  enabled: true                   # Worker Deployment renders
+  replicaCount: 2
+```
+
+The chart will then render:
+
+- `Deployment/{release}-oxy-app-worker` (N replicas of `oxy worker`)
+- `Service/{release}-oxy-app-worker` (ClusterIP on the health port, for
+  probes / in-cluster scrape only)
+- `PodDisruptionBudget/{release}-oxy-app-worker-pdb` (minAvailable: 1)
+- HPA when `worker.hpa.enabled: true` (see below)
+
+And the existing HTTP StatefulSet picks up:
+
+- `--no-workers` appended to `oxy serve`
+- `OXY_DISABLE_INPROCESS_WORKERS=1` as a belt-and-suspenders env
+
+When `worker.enabled` is left at `false` (the default) no worker
+resources are rendered — existing deploys upgrade with zero impact.
+
+## Key knobs (`worker.*`)
+
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `worker.enabled` | `false` | Master switch for the worker Deployment + Service + PDB + (optional) HPA. |
+| `worker.replicaCount` | `2` | Worker pod count. Bump this OR `worker.resources` when individual workers peg. |
+| `worker.image.repository` / `worker.image.tag` / `worker.image.pullPolicy` | inherited from `app.image*` | Pin worker fleet to a different image (canary). |
+| `worker.healthPort` | `8081` | Port `oxy worker` binds `/healthz` + `/readyz` on. Used by both probes and the worker Service. |
+| `worker.skipMigrations` | `true` | Passes `--skip-migrations` so worker replicas don't race the HTTP fleet's migrator. The HTTP StatefulSet is the canonical migrator on rollout. |
+| `worker.env.OXY_WORKER_MAX_INFLIGHT` | `"32"` | Concurrent task cap per worker process. |
+| `worker.env.OXY_WORKER_RECOVERY_INTERVAL_SECS` | `"30"` | Recovery loop (reaper pre-pass) cadence. |
+| `worker.terminationGracePeriodSeconds` | `40` | Graceful drain budget (30 s recovery + 5 s health-server + buffer). Bump if you raise `OXY_WORKER_RECOVERY_INTERVAL_SECS`. |
+| `worker.pdb.enabled` | `true` | PDB so node rollouts don't drain the fleet to zero. |
+| `worker.hpa.enabled` | `false` | Off until you wire the queue-depth metric — see below. |
+| `worker.inheritExternalSecrets` | `true` | Mount the same `externalSecrets.envSecretNames` / `fileSecrets` the HTTP fleet sees. |
+
+## `--skip-migrations` rationale
+
+Both fleets share a Postgres. If every worker pod on rollout tried to
+run migrations, they'd race for the same `INFORMATION_SCHEMA` /
+`sea_orm_migrations` rows. To avoid that:
+
+1. The HTTP StatefulSet (single pod by default) runs migrations on
+   startup — it is the canonical migrator.
+2. Worker pods skip migrations (`worker.skipMigrations: true`, the
+   default) and assume the schema is already up to date.
+
+If you'd rather run migrations as a one-shot `oxy migrate` Job, set
+`worker.skipMigrations: true` on the worker fleet AND ensure
+`oxy serve` is started after the Job completes. The chart does not (yet)
+ship that Job — see "Punted" below.
+
+## HPA wiring
+
+The HPA is **off by default** because it depends on a custom external
+metric. The canonical query, taken from
+`internal-docs/worker-fleet.md`:
+
+```sql
+SELECT count(*) FROM agentic_task_queue WHERE queue_status = 'queued';
+```
+
+Recommended pipeline:
+
+1. Run `prometheus-postgres-exporter` against the same Postgres your
+   Oxy deployment uses.
+2. Add a custom query that maps the SQL above to a metric:
+   `oxy_agentic_task_queue_depth` (override via `worker.hpa.metricName`).
+3. Expose the metric through your cluster's external-metrics adapter
+   (e.g. `k8s-prometheus-adapter`).
+4. Flip `worker.hpa.enabled: true` and tune `queueDepthThreshold` so
+   scale-up fires well before the reaper's visibility timeout (default
+   5 min) — that way the queue can't back up faster than scale events.
+
+The chart renders a v2 HPA with an `External` metric and an optional
+`Resource` metric (CPU) as a fallback when `worker.hpa.cpuUtilization`
+is set to a non-zero percentage.
+
+## Image pinning
+
+By default, the worker fleet inherits the HTTP fleet's image
+(`app.image` + `app.imageTag` falling back to `Chart.AppVersion`).
+Override `worker.image.tag` to pin a different tag — useful for canary
+rollouts where you want to shift queue drainage to a candidate image
+before flipping HTTP traffic.
+
+## Punted (intentional first-cut limitations)
+
+These follow the limitations called out in
+`internal-docs/worker-fleet.md`:
+
+- **Migration Job**: the chart does not ship a dedicated `oxy migrate`
+  Helm hook / Job. The HTTP StatefulSet is the migrator; if you need a
+  Job-based migration path, add it out-of-band.
+- **Stranded-run sweep**: the standalone worker's recovery loop only
+  runs a reaper pre-pass. Cloud-mode multi-workspace stranded-run replay
+  still requires at least one HTTP pod with in-process workers.
+- **HPA observability adapter**: the chart describes the metric, but
+  does not deploy the exporter or adapter. Wire those yourself.
+- **Worker ServiceMonitor**: the chart does not render a Prometheus
+  Operator `ServiceMonitor`. Add one against the worker Service's
+  `health` port if you scrape `/healthz` / `/readyz` directly.

--- a/charts/oxy-app/templates/NOTES.txt
+++ b/charts/oxy-app/templates/NOTES.txt
@@ -1,0 +1,56 @@
+{{/* See `templates/_worker-validation.tpl` for the corresponding fail-fast
+     guard against misconfigured topologies. */}}
+================================================================================
+oxy-app {{ .Chart.AppVersion }} — release {{ .Release.Name }}
+================================================================================
+
+HTTP fleet:
+  StatefulSet:        {{ include "oxy-app.fullname" . }}
+  Replicas:           {{ .Values.replicaCount }}
+{{- if .Values.appServer.disableInprocessWorkers }}
+  Mode:               HTTP-only (`--no-workers` + OXY_DISABLE_INPROCESS_WORKERS=1)
+                      The in-process worker AND the in-process recovery driver
+                      are disabled. The standalone `oxy worker` Deployment is
+                      the sole consumer of `agentic_task_queue`.
+{{- else }}
+  Mode:               single-process (workers run inside the HTTP server)
+                      This is the default and preserves the legacy behavior.
+                      Long-running compute and HTTP request handling share the
+                      same pod. Safe for local dev and single-node prod.
+{{- end }}
+
+Worker fleet:
+{{- if .Values.worker.enabled }}
+  Deployment:         {{ include "oxy-app.fullname" . }}-worker
+  Replicas:           {{ .Values.worker.replicaCount }} (or HPA bounds when enabled)
+  Health port:        {{ .Values.worker.healthPort | default 8081 }}
+  Liveness contract:  /healthz on the worker pod returns 200 while the durable
+                      transport + router + reaper are all alive.
+{{- if not .Values.appServer.disableInprocessWorkers }}
+
+  ⚠  Both fleets are draining the same queue.
+     `worker.enabled=true` AND `appServer.disableInprocessWorkers=false`
+     means BOTH the standalone worker fleet AND the in-process worker in
+     the HTTP StatefulSet are pulling from `agentic_task_queue`. This is
+     safe (SKIP-LOCKED prevents double-execution) but wasteful. Flip
+     `appServer.disableInprocessWorkers=true` once the worker fleet is
+     proven so the HTTP pods can drop the worker workload.
+{{- end }}
+{{- else }}
+  Status:             disabled (no resources rendered)
+                      Set `worker.enabled=true` and
+                      `appServer.disableInprocessWorkers=true` to scale the
+                      worker fleet independently of HTTP. Until then, agentic
+                      runs / builder pipelines / airway pipelines / preagg
+                      cycles execute inside the HTTP StatefulSet pod.
+{{- end }}
+
+Coordination surface:
+  Both fleets must point at the SAME Postgres. `OXY_DATABASE_URL` flows
+  through the existing `app.env.OXY_DATABASE_URL` / external-secret pipeline
+  for both the StatefulSet and the worker Deployment.
+
+References:
+  - chart guide:        charts/oxy-app/docs/worker-fleet.md
+  - upstream design:    oxygen-internal#2409
+  - operator runbook:   oxygen-internal `internal-docs/worker-fleet.md`

--- a/charts/oxy-app/templates/_worker-validation.tpl
+++ b/charts/oxy-app/templates/_worker-validation.tpl
@@ -1,0 +1,31 @@
+{{- /*
+Helm-time guard against the silent-stall misconfiguration where the
+HTTP fleet is told NOT to drain the queue (`appServer.disableInprocessWorkers`)
+but no standalone worker fleet is rendered (`worker.enabled: false`).
+
+In that configuration nothing pulls from `agentic_task_queue`:
+   - HTTP server sees `--no-workers` / `OXY_DISABLE_INPROCESS_WORKERS=1`
+     and skips both the in-process worker AND the recovery driver.
+   - `oxy worker` Deployment is not rendered, so no out-of-process
+     consumer exists either.
+Result: agentic runs, builder pipelines, airway runs, preagg cycles
+all enqueue successfully but never execute. Symptoms surface as runs
+stuck in `queued`, the queue-depth alert paging on-call after the
+threshold breach, and operators chasing a phantom database issue.
+
+The reverse misconfiguration (`worker.enabled: true` AND
+`appServer.disableInprocessWorkers: false`) is benign — both fleets
+drain the same queue concurrently. It wastes a worker pod, but the
+SKIP-LOCKED semantics prevent double-execution. Skip the guard there
+and let the user wire the topology as they intend.
+*/}}
+{{- define "oxy-app.validateWorkerTopology" -}}
+{{- if and .Values.appServer.disableInprocessWorkers (not .Values.worker.enabled) -}}
+{{- fail (printf "%s%s%s%s%s"
+  "[oxy-app] Invalid worker topology: appServer.disableInprocessWorkers=true "
+  "but worker.enabled=false. The HTTP fleet is configured to skip in-process "
+  "workers, so nothing will drain the agentic_task_queue. Either set "
+  "worker.enabled=true to render the standalone oxy worker Deployment, or set "
+  "appServer.disableInprocessWorkers=false to keep the in-process worker.") -}}
+{{- end -}}
+{{- end -}}

--- a/charts/oxy-app/templates/statefulset.yaml
+++ b/charts/oxy-app/templates/statefulset.yaml
@@ -1,6 +1,8 @@
 {{/*
 Define git clone paths
 */}}
+{{- /* Fail fast if the worker topology is misconfigured. See _worker-validation.tpl. */}}
+{{- include "oxy-app.validateWorkerTopology" . -}}
 {{- $gitCloneDir := printf "%s/%s" .Values.persistence.mountPath (default "repo" .Values.git.cloneDir) -}}
 {{- $workingDir := $gitCloneDir -}}
 {{- if and .Values.git.workingDir (ne .Values.git.workingDir "") -}}

--- a/charts/oxy-app/templates/statefulset.yaml
+++ b/charts/oxy-app/templates/statefulset.yaml
@@ -303,7 +303,7 @@ spec:
             - sh
             - -c
             - |
-              exec oxy serve{{- if .Values.git.enabled }} --local{{- end }}{{- if .Values.app.internalHost }} --internal-host {{ .Values.app.internalHost }} --internal-port {{ .Values.app.internalPort }}{{- end }}
+              exec oxy serve{{- if .Values.git.enabled }} --local{{- end }}{{- if .Values.app.internalHost }} --internal-host {{ .Values.app.internalHost }} --internal-port {{ .Values.app.internalPort }}{{- end }}{{- if .Values.appServer.disableInprocessWorkers }} --no-workers{{- end }}
           {{- end }}
           {{- if .Values.git.enabled }}
           workingDir: {{ $workingDir }}
@@ -327,6 +327,14 @@ spec:
             {{- else }}
             - name: OXY_STATE_DIR
               value: {{ printf "%s/%s" .Values.persistence.mountPath .Values.persistence.folder | quote }}
+            {{- end }}
+
+            # Belt-and-suspenders for the --no-workers CLI flag: HTTP-only fleets
+            # paired with a standalone `oxy worker` deployment must skip the
+            # in-process workers so they don't double-drive the queue.
+            {{- if .Values.appServer.disableInprocessWorkers }}
+            - name: OXY_DISABLE_INPROCESS_WORKERS
+              value: "1"
             {{- end }}
 
             # Database URL Configuration

--- a/charts/oxy-app/templates/worker-deployment.yaml
+++ b/charts/oxy-app/templates/worker-deployment.yaml
@@ -1,0 +1,228 @@
+{{- if .Values.worker.enabled }}
+{{- /*
+Standalone `oxy worker` fleet — see oxygen-internal#2409 and
+`internal-docs/worker-fleet.md` for the operational shape.
+
+This Deployment runs the durable orchestrator out-of-process so the
+HTTP fleet (StatefulSet) and worker fleet can scale independently.
+Both fleets must share the SAME Postgres (`OXY_DATABASE_URL`).
+The HTTP StatefulSet should run with `appServer.disableInprocessWorkers: true`.
+*/}}
+{{- $workerImageRepo := default .Values.app.image .Values.worker.image.repository -}}
+{{- $workerImageTag := default (default .Chart.AppVersion .Values.app.imageTag) .Values.worker.image.tag -}}
+{{- $workerImagePullPolicy := default .Values.app.imagePullPolicy .Values.worker.image.pullPolicy -}}
+{{- $workerSa := default (include "oxy-app.serviceAccountName" .) .Values.worker.serviceAccountName -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "oxy-app.fullname" . }}-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oxy-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "oxy-app.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Keep at least one worker alive during rollout; allow one extra to
+      # smooth the cutover. Drain time can be up to 35 s per pod.
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        {{- include "oxy-app.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+        {{- with .Values.worker.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.worker.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if ne $workerSa "" }}
+      serviceAccountName: {{ $workerSa | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
+      {{- with .Values.worker.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: worker
+          image: "{{ $workerImageRepo }}:{{ $workerImageTag }}"
+          imagePullPolicy: {{ $workerImagePullPolicy }}
+          {{- with .Values.worker.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.worker.command (gt (len .Values.worker.command) 0) }}
+          command:
+            {{- range .Values.worker.command }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- else }}
+          command:
+            - sh
+            - -c
+            - |
+              exec oxy worker --health-port {{ .Values.worker.healthPort }}{{- if .Values.worker.skipMigrations }} --skip-migrations{{- end }}
+          {{- end }}
+          ports:
+            - name: health
+              containerPort: {{ .Values.worker.healthPort }}
+              protocol: TCP
+          env:
+            # Database URL Configuration — mirrors the HTTP StatefulSet
+            # precedence so both fleets agree on the same Postgres.
+            {{- if and .Values.env.OXY_DATABASE_URL (ne .Values.env.OXY_DATABASE_URL "") }}
+            - name: OXY_DATABASE_URL
+              value: {{ .Values.env.OXY_DATABASE_URL | quote }}
+            {{- else if and .Values.database.external.enabled (ne .Values.database.external.connectionString "") }}
+            - name: OXY_DATABASE_URL
+              value: {{ .Values.database.external.connectionString | quote }}
+            {{- else if .Values.database.external.enabled }}
+            - name: OXY_DATABASE_URL
+              value: {{ printf "postgresql://%s:%s@%s:%v/%s"
+                .Values.database.external.user
+                .Values.database.external.password
+                .Values.database.external.host
+                .Values.database.external.port
+                .Values.database.external.database | quote }}
+            {{- else if .Values.database.postgres.enabled }}
+            - name: OXY_DATABASE_URL
+              {{- $pgHost := "" }}
+              {{- if .Values.postgres.fullnameOverride }}
+                {{- $pgHost = printf "%s.%s.svc.cluster.local" .Values.postgres.fullnameOverride .Release.Namespace }}
+              {{- else if .Values.database.postgres.host }}
+                {{- $pgHost = .Values.database.postgres.host }}
+              {{- else }}
+                {{- $pgHost = printf "%s-postgres.%s.svc.cluster.local" .Release.Name .Release.Namespace }}
+              {{- end }}
+              value: {{ printf "postgresql://%s:%s@%s:%v/%s"
+                (default "postgres" .Values.postgres.userDatabase.user.value)
+                (default "postgres" .Values.postgres.userDatabase.password.value)
+                $pgHost
+                .Values.database.postgres.port
+                (default "postgres" .Values.postgres.userDatabase.name.value) | quote }}
+            {{- end }}
+
+            # Worker-specific tunables (see worker.* in values.yaml).
+            - name: OXY_WORKER_HEALTH_PORT
+              value: {{ .Values.worker.healthPort | quote }}
+            {{- range $key, $value := .Values.worker.env }}
+            {{- if ne $value "" }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+
+            # Pass through general env vars from the top-level `env` map
+            # (skipping the ones we've already handled above).
+            {{- range $key, $value := .Values.env }}
+            {{- if and (ne $key "OXY_STATE_DIR") (ne $key "OXY_DATABASE_URL") }}
+            {{- if ne $value "" }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+
+            {{- with .Values.worker.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+          {{- if or .Values.configMap.enabled (and .Values.worker.inheritExternalSecrets (gt (len .Values.externalSecrets.envSecretNames) 0)) (gt (len .Values.worker.extraEnvFrom) 0) }}
+          envFrom:
+            {{- if .Values.configMap.enabled }}
+            - configMapRef:
+                name: {{ include "oxy-app.fullname" . }}-config
+            {{- end }}
+            {{- if .Values.worker.inheritExternalSecrets }}
+            {{- range .Values.externalSecrets.envSecretNames }}
+            - secretRef:
+                name: {{ . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.worker.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+
+          {{- with .Values.worker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- with .Values.worker.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.worker.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.worker.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          volumeMounts:
+            {{- /* Inherit env-secret file mounts so the worker sees the same secret surface. */}}
+            {{- if .Values.worker.inheritExternalSecrets }}
+            {{- range $idx, $secretName := .Values.externalSecrets.envSecretNames }}
+            - name: env-secret-{{ $idx }}
+              mountPath: /secrets/env/{{ $secretName }}
+              readOnly: true
+            {{- end }}
+            {{- range $idx, $fileSecret := .Values.externalSecrets.fileSecrets }}
+            - name: file-secret-{{ $idx }}
+              mountPath: /secrets/files/{{ $fileSecret.name }}
+              readOnly: true
+            {{- end }}
+            {{- end }}
+            {{- with .Values.worker.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+        {{- with .Values.worker.extraSidecars }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+
+      volumes:
+        {{- if .Values.worker.inheritExternalSecrets }}
+        {{- range $idx, $secretName := .Values.externalSecrets.envSecretNames }}
+        - name: env-secret-{{ $idx }}
+          secret:
+            secretName: {{ $secretName | quote }}
+            optional: true
+        {{- end }}
+        {{- range $idx, $fileSecret := .Values.externalSecrets.fileSecrets }}
+        - name: file-secret-{{ $idx }}
+          secret:
+            secretName: {{ $fileSecret.name | quote }}
+            optional: true
+        {{- end }}
+        {{- end }}
+        {{- with .Values.worker.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/oxy-app/templates/worker-hpa.yaml
+++ b/charts/oxy-app/templates/worker-hpa.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.worker.enabled .Values.worker.hpa.enabled }}
+{{- /*
+HorizontalPodAutoscaler for the worker fleet.
+
+Off by default because it depends on a Prometheus + prometheus-postgres-exporter
+metric named `worker.hpa.metricName` (default `oxy_agentic_task_queue_depth`)
+that runs the canonical query:
+
+  SELECT count(*) FROM agentic_task_queue WHERE queue_status = 'queued';
+
+Wire that through your cluster's external-metrics adapter, then flip
+`worker.hpa.enabled: true` and tune `queueDepthThreshold`.
+
+Trigger scale-up well below the reaper's visibility-timeout so the queue
+doesn't back up faster than scale events fire.
+*/}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "oxy-app.fullname" . }}-worker-hpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oxy-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "oxy-app.fullname" . }}-worker
+  minReplicas: {{ .Values.worker.hpa.minReplicas }}
+  maxReplicas: {{ .Values.worker.hpa.maxReplicas }}
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: {{ .Values.worker.hpa.metricName | quote }}
+        target:
+          type: AverageValue
+          averageValue: {{ .Values.worker.hpa.queueDepthThreshold | quote }}
+    {{- if and .Values.worker.hpa.cpuUtilization (gt (int .Values.worker.hpa.cpuUtilization) 0) }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.hpa.cpuUtilization }}
+    {{- end }}
+  {{- with .Values.worker.hpa.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/oxy-app/templates/worker-pdb.yaml
+++ b/charts/oxy-app/templates/worker-pdb.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.worker.enabled .Values.worker.pdb.enabled }}
+{{- /*
+PodDisruptionBudget for the worker fleet — bounds voluntary disruption
+during node rollouts. Graceful shutdown can take up to 35s per worker.
+*/}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "oxy-app.fullname" . }}-worker-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oxy-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  selector:
+    matchLabels:
+      {{- include "oxy-app.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  {{- if .Values.worker.pdb.minAvailable }}
+  minAvailable: {{ .Values.worker.pdb.minAvailable }}
+  {{- else if .Values.worker.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.worker.pdb.maxUnavailable }}
+  {{- else }}
+  # Default to minAvailable: 1 when neither is set.
+  minAvailable: 1
+  {{- end }}
+{{- end }}

--- a/charts/oxy-app/templates/worker-service.yaml
+++ b/charts/oxy-app/templates/worker-service.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.worker.enabled .Values.worker.service.enabled }}
+{{- /*
+ClusterIP service fronting the worker fleet on the health port.
+Workers are driven by Postgres LISTEN/NOTIFY, not by HTTP traffic, so
+this Service exists only for in-cluster `/healthz` / `/readyz` probes
+and observability (e.g. Prometheus scrape targets).
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "oxy-app.fullname" . }}-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oxy-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+  {{- with .Values.worker.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.worker.service.type }}
+  selector:
+    {{- include "oxy-app.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+  ports:
+    - name: health
+      port: {{ .Values.worker.service.port }}
+      targetPort: {{ .Values.worker.healthPort }}
+      protocol: TCP
+{{- end }}

--- a/charts/oxy-app/test-values/default-values.yaml
+++ b/charts/oxy-app/test-values/default-values.yaml
@@ -1,10 +1,25 @@
 # Integration test with default minimal configuration
+#
+# Smallest helm-install shape that the chart will actually start. Modern
+# oxy serve requires OXY_DATABASE_URL — there is no sqlite fallback
+# (intentional, see statefulset.yaml comment on the OXY_DATABASE_URL
+# branch). So "default" here means "minimal viable production-ish
+# install": the postgres subchart plus the oxy server.
+#
+# Previously this file disabled the postgres subchart and pinned image
+# 0.4.0, which silently broke the integration suite when the chart's
+# DB-URL fallback was removed. The CI failure surfaced as a 3-minute
+# "StatefulSet not ready" timeout with no pod-level cause printed.
+# `scripts/test.sh` now dumps kubectl describe + pod logs on failure
+# so future regressions are visible at a glance.
 nameOverride: "oxy-test-default"
 fullnameOverride: "oxy-test-default"
 
 app:
   image: "ghcr.io/oxy-hq/oxygen"
-  imageTag: "0.4.0"
+  # Match Chart.appVersion so we exercise the binary that ships with the
+  # chart, not a half-year-old tag.
+  imageTag: "0.5.49"
   imagePullPolicy: "IfNotPresent"
 
 replicaCount: 1
@@ -14,16 +29,31 @@ service:
   port: 80
   targetPort: 3000
 
-# Disable external dependencies for testing
+# Enable the postgres subchart so OXY_DATABASE_URL is wired and the oxy
+# server can start. Test config mirrors with-postgres-values.yaml so the
+# default test is a strict subset of the postgres-specific test.
 database:
   postgres:
-    enabled: false
+    enabled: true
 
-# Use minimal resources for CI
+postgres:
+  fullnameOverride: "test-default-db"
+  userDatabase:
+    name:
+      value: "testdb"
+    user:
+      value: "testuser"
+    password:
+      value: "testpass"
+
+# Bumped from 128Mi → 512Mi. The Rust binary plus startup migrations
+# need headroom; 128Mi was tight enough that pods spent the full 3min
+# install timeout in OOMKilled / CrashLoop without ever passing
+# readiness. CPU stays modest because kind nodes are constrained.
 resources:
   limits:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 500m
+    memory: 512Mi
   requests:
-    cpu: 50m
-    memory: 64Mi
+    cpu: 100m
+    memory: 256Mi

--- a/charts/oxy-app/test-values/production-like-values.yaml
+++ b/charts/oxy-app/test-values/production-like-values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: "test-production"
 
 app:
   image: "ghcr.io/oxy-hq/oxygen"  # Use nginx for testing instead of real app
-  imageTag: "0.4.0"
+  imageTag: "0.5.49"
   imagePullPolicy: "IfNotPresent"
   replicaCount: 1
 
@@ -29,11 +29,11 @@ env:
 # Resource configuration similar to production but smaller for CI
 resources:
   requests:
-    cpu: "100m"
-    memory: "128Mi"
+    cpu: "500m"
+    memory: "512Mi"
   limits:
-    cpu: "200m"
-    memory: "256Mi"
+    cpu: "500m"
+    memory: "512Mi"
 
 # Test persistence with smaller size
 persistence:
@@ -72,7 +72,7 @@ ingress:
 # Disable external database dependency for this test
 database:
   postgres:
-    enabled: false
+    enabled: true
 
 # Enable PodDisruptionBudget in this production-like test values
 pdb:

--- a/charts/oxy-app/test-values/security-hardened-values.yaml
+++ b/charts/oxy-app/test-values/security-hardened-values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: "oxy-test-secure"
 
 app:
   image: "ghcr.io/oxy-hq/oxygen"
-  imageTag: "0.4.0"
+  imageTag: "0.5.49"
   imagePullPolicy: "Always"  # Always pull for security
   replicaCount: 1
   port: 3000
@@ -12,11 +12,11 @@ app:
 # Minimal resources for security testing
 resources:
   requests:
-    cpu: "50m"
-    memory: "64Mi"
+    cpu: "500m"
+    memory: "512Mi"
   limits:
-    cpu: "100m"
-    memory: "128Mi"
+    cpu: "500m"
+    memory: "512Mi"
 
 # Secure environment
 env:
@@ -87,7 +87,7 @@ git:
 
 database:
   postgres:
-    enabled: false
+    enabled: true
 
 externalSecrets:
   create: false

--- a/charts/oxy-app/test-values/with-ingress-values.yaml
+++ b/charts/oxy-app/test-values/with-ingress-values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: "oxy-test-ingress"
 
 app:
   image: "ghcr.io/oxy-hq/oxygen"
-  imageTag: "0.4.0"
+  imageTag: "0.5.49"
   imagePullPolicy: "IfNotPresent"
 
 replicaCount: 1
@@ -29,12 +29,12 @@ ingress:
 # Disable external dependencies
 database:
   postgres:
-    enabled: false
+    enabled: true
 
 resources:
   limits:
-    cpu: 100m
-    memory: 128Mi
+    cpu: "500m"
+    memory: "512Mi"
   requests:
-    cpu: 50m
-    memory: 64Mi
+    cpu: "500m"
+    memory: "512Mi"

--- a/charts/oxy-app/test-values/with-persistence-values.yaml
+++ b/charts/oxy-app/test-values/with-persistence-values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: "oxy-test-persist"
 
 app:
   image: "ghcr.io/oxy-hq/oxygen"
-  imageTag: "0.4.0"
+  imageTag: "0.5.49"
   imagePullPolicy: "IfNotPresent"
   replicaCount: 1
 
@@ -26,16 +26,16 @@ env:
 # Resource limits for CI
 resources:
   requests:
-    cpu: "50m"
-    memory: "64Mi"
+    cpu: "500m"
+    memory: "512Mi"
   limits:
-    cpu: "100m"
-    memory: "128Mi"
+    cpu: "500m"
+    memory: "512Mi"
 
 # Disable external dependencies
 database:
   postgres:
-    enabled: false
+    enabled: true
 
 git:
   enabled: false

--- a/charts/oxy-app/test-values/with-postgres-values.yaml
+++ b/charts/oxy-app/test-values/with-postgres-values.yaml
@@ -4,7 +4,10 @@ fullnameOverride: "oxy-test-postgres"
 
 app:
   image: "ghcr.io/oxy-hq/oxygen"
-  imageTag: "0.4.0"
+  # Match Chart.appVersion. The previous 0.4.0 pin pre-dates the
+  # chart's DB-URL handling refactor and caused silent startup
+  # failures.
+  imageTag: "0.5.49"
   imagePullPolicy: "IfNotPresent"
 
 replicaCount: 1
@@ -33,8 +36,8 @@ postgres:
 
 resources:
   limits:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 500m
+    memory: 512Mi
   requests:
-    cpu: 50m
-    memory: 64Mi
+    cpu: 100m
+    memory: 256Mi

--- a/charts/oxy-app/tests/no_workers_flag_test.yaml
+++ b/charts/oxy-app/tests/no_workers_flag_test.yaml
@@ -1,0 +1,59 @@
+suite: --no-workers flag on the HTTP StatefulSet
+templates:
+  - statefulset.yaml
+
+tests:
+  - it: does NOT pass --no-workers by default (single-process mode)
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "--no-workers"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OXY_DISABLE_INPROCESS_WORKERS
+            value: "1"
+
+  - it: appends --no-workers to the serve command when appServer.disableInprocessWorkers is true
+    set:
+      appServer:
+        disableInprocessWorkers: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "exec oxy serve.*--no-workers"
+
+  - it: also sets OXY_DISABLE_INPROCESS_WORKERS=1 as a belt-and-suspenders
+    set:
+      appServer:
+        disableInprocessWorkers: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OXY_DISABLE_INPROCESS_WORKERS
+            value: "1"
+
+  - it: composes --no-workers alongside the existing --internal-host flag
+    set:
+      appServer:
+        disableInprocessWorkers: true
+      app:
+        internalHost: "0.0.0.0"
+        internalPort: 3001
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "--internal-host 0.0.0.0 --internal-port 3001 --no-workers"
+
+  - it: composes --no-workers alongside --local when git is enabled
+    set:
+      appServer:
+        disableInprocessWorkers: true
+      git:
+        enabled: true
+        repository: "https://github.com/example/repo.git"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "exec oxy serve --local.*--no-workers"

--- a/charts/oxy-app/tests/no_workers_flag_test.yaml
+++ b/charts/oxy-app/tests/no_workers_flag_test.yaml
@@ -16,6 +16,10 @@ tests:
 
   - it: appends --no-workers to the serve command when appServer.disableInprocessWorkers is true
     set:
+      # The topology guard requires worker.enabled=true whenever the HTTP
+      # fleet drops in-process workers. See _worker-validation.tpl.
+      worker:
+        enabled: true
       appServer:
         disableInprocessWorkers: true
     asserts:
@@ -25,6 +29,8 @@ tests:
 
   - it: also sets OXY_DISABLE_INPROCESS_WORKERS=1 as a belt-and-suspenders
     set:
+      worker:
+        enabled: true
       appServer:
         disableInprocessWorkers: true
     asserts:
@@ -36,6 +42,8 @@ tests:
 
   - it: composes --no-workers alongside the existing --internal-host flag
     set:
+      worker:
+        enabled: true
       appServer:
         disableInprocessWorkers: true
       app:
@@ -48,6 +56,8 @@ tests:
 
   - it: composes --no-workers alongside --local when git is enabled
     set:
+      worker:
+        enabled: true
       appServer:
         disableInprocessWorkers: true
       git:

--- a/charts/oxy-app/tests/worker_disabled_test.yaml
+++ b/charts/oxy-app/tests/worker_disabled_test.yaml
@@ -1,0 +1,35 @@
+suite: worker fleet zero-impact upgrade (worker.enabled=false)
+templates:
+  - worker-deployment.yaml
+  - worker-service.yaml
+  - worker-pdb.yaml
+  - worker-hpa.yaml
+
+# No `set:` block — using chart defaults to prove that an existing
+# deployment upgrading to this chart version sees NO new worker
+# resources unless they explicitly opt in.
+
+tests:
+  - it: does not render the worker Deployment by default
+    template: worker-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render the worker Service by default
+    template: worker-service.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render the worker PDB by default
+    template: worker-pdb.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render the worker HPA by default
+    template: worker-hpa.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/oxy-app/tests/worker_test.yaml
+++ b/charts/oxy-app/tests/worker_test.yaml
@@ -1,0 +1,340 @@
+suite: worker fleet tests (worker.enabled=true)
+templates:
+  - worker-deployment.yaml
+  - worker-service.yaml
+  - worker-pdb.yaml
+  - worker-hpa.yaml
+
+set:
+  worker:
+    enabled: true
+
+tests:
+  # ---------- Deployment ----------
+  - it: renders the worker Deployment with the expected name
+    template: worker-deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-oxy-app-worker
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: worker
+
+  - it: sets the default replica count to 2
+    template: worker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+
+  - it: honors a custom replicaCount
+    template: worker-deployment.yaml
+    set:
+      worker:
+        replicaCount: 5
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 5
+
+  - it: uses the same image as the HTTP app by default
+    template: worker-deployment.yaml
+    set:
+      app:
+        image: ghcr.io/oxy-hq/oxygen
+        imageTag: "1.2.3"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/oxy-hq/oxygen:1.2.3
+
+  - it: allows pinning a different image tag for the worker fleet
+    template: worker-deployment.yaml
+    set:
+      worker:
+        image:
+          tag: "9.9.9-canary"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/oxy-hq/oxygen:9.9.9-canary
+
+  - it: invokes `oxy worker` with --health-port and --skip-migrations by default
+    template: worker-deployment.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "exec oxy worker --health-port 8081 --skip-migrations"
+
+  - it: drops --skip-migrations when worker.skipMigrations is false
+    template: worker-deployment.yaml
+    set:
+      worker:
+        skipMigrations: false
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "exec oxy worker --health-port 8081\n"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "--skip-migrations"
+
+  - it: exposes the health port on the container
+    template: worker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: health
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8081
+
+  - it: wires liveness probe to /healthz on the health port
+    template: worker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8081
+
+  - it: wires readiness probe to /readyz on the health port
+    template: worker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8081
+
+  - it: sets terminationGracePeriodSeconds to 40 (drain budget)
+    template: worker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 40
+
+  - it: sets OXY_WORKER_MAX_INFLIGHT and OXY_WORKER_RECOVERY_INTERVAL_SECS
+    template: worker-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OXY_WORKER_MAX_INFLIGHT
+            value: "32"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OXY_WORKER_RECOVERY_INTERVAL_SECS
+            value: "30"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OXY_WORKER_HEALTH_PORT
+            value: "8081"
+
+  - it: propagates the top-level OXY_DATABASE_URL into the worker pod
+    template: worker-deployment.yaml
+    set:
+      env:
+        OXY_DATABASE_URL: "postgresql://oxy:pw@db.example:5432/oxy"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OXY_DATABASE_URL
+            value: "postgresql://oxy:pw@db.example:5432/oxy"
+
+  - it: honors a custom health port end-to-end
+    template: worker-deployment.yaml
+    set:
+      worker:
+        healthPort: 9090
+        livenessProbe:
+          httpGet: { path: /healthz, port: 9090 }
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet: { path: /readyz, port: 9090 }
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 3
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "--health-port 9090"
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 9090
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 9090
+
+  - it: applies the default resource requests
+    template: worker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
+
+  - it: inherits external env-secret references when enabled
+    template: worker-deployment.yaml
+    set:
+      externalSecrets:
+        envSecretNames:
+          - oxy-llm-keys
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: oxy-llm-keys
+
+  - it: skips external secret inheritance when toggled off
+    template: worker-deployment.yaml
+    set:
+      externalSecrets:
+        envSecretNames:
+          - oxy-llm-keys
+      worker:
+        inheritExternalSecrets: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].envFrom
+
+  # ---------- Service ----------
+  - it: renders a ClusterIP service for the worker health port
+    template: worker-service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-oxy-app-worker
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 8081
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 8081
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: worker
+
+  - it: omits the worker service when worker.service.enabled is false
+    template: worker-service.yaml
+    set:
+      worker:
+        service:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ---------- PDB ----------
+  - it: "renders a PDB with minAvailable=1 by default"
+    template: worker-pdb.yaml
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-oxy-app-worker-pdb
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: worker
+
+  - it: honors explicit maxUnavailable when minAvailable is empty
+    template: worker-pdb.yaml
+    set:
+      worker:
+        pdb:
+          minAvailable: ""
+          maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: omits the PDB when worker.pdb.enabled is false
+    template: worker-pdb.yaml
+    set:
+      worker:
+        pdb:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ---------- HPA ----------
+  - it: does NOT render the HPA by default (custom metric not wired)
+    template: worker-hpa.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the HPA when worker.hpa.enabled is true
+    template: worker-hpa.yaml
+    set:
+      worker:
+        hpa:
+          enabled: true
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-oxy-app-worker-hpa
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: RELEASE-NAME-oxy-app-worker
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+      - equal:
+          path: spec.metrics[0].type
+          value: External
+      - equal:
+          path: spec.metrics[0].external.metric.name
+          value: oxy_agentic_task_queue_depth
+      - equal:
+          path: spec.metrics[0].external.target.averageValue
+          value: "100"
+
+  - it: appends a CPU resource metric when cpuUtilization is set
+    template: worker-hpa.yaml
+    set:
+      worker:
+        hpa:
+          enabled: true
+          cpuUtilization: 70
+    asserts:
+      - equal:
+          path: spec.metrics[1].type
+          value: Resource
+      - equal:
+          path: spec.metrics[1].resource.name
+          value: cpu
+      - equal:
+          path: spec.metrics[1].resource.target.averageUtilization
+          value: 70

--- a/charts/oxy-app/tests/worker_topology_guard_test.yaml
+++ b/charts/oxy-app/tests/worker_topology_guard_test.yaml
@@ -1,0 +1,49 @@
+suite: worker topology fail-fast guard
+templates:
+  - statefulset.yaml
+
+tests:
+  - it: refuses to render when --no-workers is set but worker.enabled is false
+    set:
+      appServer:
+        disableInprocessWorkers: true
+      worker:
+        enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "[oxy-app] Invalid worker topology: appServer.disableInprocessWorkers=true but worker.enabled=false. The HTTP fleet is configured to skip in-process workers, so nothing will drain the agentic_task_queue. Either set worker.enabled=true to render the standalone oxy worker Deployment, or set appServer.disableInprocessWorkers=false to keep the in-process worker."
+
+  - it: allows the legacy single-process default (workers run in-process)
+    # No `set` block — pure defaults: disableInprocessWorkers=false,
+    # worker.enabled=false. The statefulset must render normally.
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: StatefulSet
+
+  - it: allows the split-fleet topology (HTTP-only + standalone worker)
+    set:
+      appServer:
+        disableInprocessWorkers: true
+      worker:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: StatefulSet
+
+  - it: allows the redundant-drain topology (both fleets enabled)
+    # Wasteful but safe. The guard is INTENTIONALLY narrow — it only
+    # catches the silent-stall case where nothing drains the queue.
+    set:
+      appServer:
+        disableInprocessWorkers: false
+      worker:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: StatefulSet

--- a/charts/oxy-app/values.yaml
+++ b/charts/oxy-app/values.yaml
@@ -19,6 +19,19 @@ app:
   internalPort: 3001
   internalHost: ""  # Set to "0.0.0.0" to enable internal API on all interfaces
 
+# HTTP server (`oxy serve`) tunables.
+# Use this stanza to pair the StatefulSet HTTP fleet with a separate
+# worker fleet (see `worker.*`) — when disableInprocessWorkers is true the
+# HTTP server runs as HTTP-only (`--no-workers`) and standalone
+# `oxy worker` pods drain the durable task queue.
+appServer:
+  # When true, append `--no-workers` to the `oxy serve` command and set
+  # OXY_DISABLE_INPROCESS_WORKERS=1 so the HTTP server skips startup
+  # recovery and the in-process driver loop. Required when a standalone
+  # worker fleet is handling agentic execution. Default false so existing
+  # deployments are unaffected on upgrade.
+  disableInprocessWorkers: false
+
 # Ingress configuration
 # Enable and configure Kubernetes Ingress for the application.
 ingress:

--- a/charts/oxy-app/values.yaml
+++ b/charts/oxy-app/values.yaml
@@ -488,3 +488,148 @@ pdb:
   maxUnavailable: ""
   # Optional selector labels to narrow the PDB selector. Merges with chart selectorLabels when provided.
   selector: {}
+
+# ---------------------------------------------------------------------------
+# Standalone worker fleet (`oxy worker`)
+# ---------------------------------------------------------------------------
+# Opt-in deployment of the standalone `oxy worker` process introduced in
+# oxygen-internal#2409 (`feat/worker-fleet-separation`). When
+# `worker.enabled: false` (default) NO worker resources are rendered, so
+# existing deployments upgrade with zero impact.
+#
+# Topology when enabled:
+#   - HTTP fleet (StatefulSet): run with `appServer.disableInprocessWorkers: true`
+#     so the HTTP server skips in-process workers and is HTTP-only.
+#   - Worker fleet (Deployment, this stanza): N replicas drain the
+#     `agentic_task_queue` table via `SELECT ... FOR UPDATE SKIP LOCKED`.
+#   - Both point at the SAME Postgres (`OXY_DATABASE_URL`).
+#
+# Operational requirements live in oxygen-internal `internal-docs/worker-fleet.md`.
+worker:
+  enabled: false
+  # Number of worker pods. Scale independently of the HTTP fleet.
+  replicaCount: 2
+  # Image: inherits from .Values.app.image / .Values.app.imageTag when left empty.
+  # Override here only when you intentionally want the worker fleet to pin
+  # to a different tag (e.g. canary rollouts).
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: ""
+  # Override the container command. When empty, the chart uses
+  #   exec oxy worker --health-port <healthPort> [--skip-migrations]
+  command: []
+  # Worker process tunables. These mirror the `oxy worker` env vars / flags
+  # documented in oxygen-internal `internal-docs/worker-fleet.md`.
+  env:
+    # Concurrent task cap per worker process.
+    OXY_WORKER_MAX_INFLIGHT: "32"
+    # Cadence of the recovery loop (reaper pre-pass) in seconds.
+    OXY_WORKER_RECOVERY_INTERVAL_SECS: "30"
+  # Port the worker binds `/healthz` and `/readyz` on. Used by both probes
+  # and the worker `ClusterIP` Service. Stays inside the cluster — no
+  # ingress / public exposure.
+  healthPort: 8081
+  # When true, pass `--skip-migrations` to `oxy worker`. The HTTP StatefulSet
+  # is the canonical migrator on rollout; workers must skip so they don't
+  # race the HTTP fleet on the same schema changes. Leave true unless you
+  # know you've moved migrations out to a dedicated Job.
+  skipMigrations: true
+  # Pod-level extras
+  serviceAccountName: ""  # If empty, falls back to the main chart serviceAccount
+  podAnnotations: {}
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # Extra env entries appended to the worker container after the defaults
+  # above. Format: list of EnvVar objects (name/value or name/valueFrom).
+  extraEnv: []
+  # Extra envFrom entries (configMapRef / secretRef) for the worker container.
+  extraEnvFrom: []
+  # Resources. Defaults sized for a single worker process with the default
+  # max-inflight of 32. Bump CPU / memory before bumping replicaCount when
+  # individual workers are pegged.
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  # Liveness probe: `/healthz` — 200 once the process is up.
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: 8081
+    initialDelaySeconds: 5
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  # Readiness probe: `/readyz` — 200 only when router_connected + recovery_alive.
+  # Flips to 503 during graceful shutdown so k8s yanks the pod out of the
+  # Service before in-flight tasks drain.
+  readinessProbe:
+    httpGet:
+      path: /readyz
+      port: 8081
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 3
+  # Graceful shutdown takes up to 35s (30s recovery drain + 5s health server drain).
+  # Bump if you raise OXY_WORKER_RECOVERY_INTERVAL_SECS materially.
+  terminationGracePeriodSeconds: 40
+  # Optional preStop hook. Empty by default — the worker's own SIGTERM
+  # handler flips /readyz to 503 and drives the drain.
+  lifecycle: {}
+  # securityContext block applied to the worker pod.
+  securityContext:
+    fsGroup: 1000
+  # Worker container securityContext (e.g. runAsNonRoot, readOnlyRootFilesystem).
+  containerSecurityContext: {}
+  # ClusterIP service that fronts the worker pods on `healthPort`. Useful
+  # for in-cluster scrapers / debugging; not required for queue drainage
+  # (workers are driven by Postgres LISTEN/NOTIFY, not HTTP).
+  service:
+    enabled: true
+    type: ClusterIP
+    port: 8081
+    annotations: {}
+  # PodDisruptionBudget. Bounds voluntary disruption so a fleet of 2+
+  # workers doesn't drain to zero during a node rollout.
+  pdb:
+    enabled: true
+    # minAvailable wins over maxUnavailable when both are set.
+    minAvailable: 1
+    maxUnavailable: ""
+  # HorizontalPodAutoscaler. OFF by default because it requires a custom
+  # Prometheus + prometheus-postgres-exporter metric pipeline reading queue
+  # depth from `agentic_task_queue WHERE queue_status='queued'`. When you
+  # have that wired, flip `enabled: true` and tune
+  # `queueDepthThreshold` — see WORKER_FLEET.md for the exporter query.
+  #
+  # The chart renders a v2 HPA with an `External` metric named
+  # `oxy_agentic_task_queue_depth` (override via `metricName`). Adapt to
+  # your cluster's metrics adapter as needed.
+  hpa:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 10
+    metricName: oxy_agentic_task_queue_depth
+    queueDepthThreshold: 100
+    # Optional fallback Resource metric (CPU) — paired with the external
+    # metric so the HPA still has a signal when the queue exporter is down.
+    cpuUtilization: 0  # 0 = disabled. Set to e.g. 70 to enable.
+    # Optional scale behavior block. Leave empty for the controller defaults.
+    behavior: {}
+  # Extra sidecar containers for the worker pod.
+  extraSidecars: []
+  # Extra volumes / mounts.
+  extraVolumes: []
+  extraVolumeMounts: []
+  # Inherit external secret env mounts from the top-level
+  # externalSecrets.envSecretNames so workers see the same DB / LLM keys
+  # as the HTTP fleet. Disable if your worker pods use a different secret
+  # surface.
+  inheritExternalSecrets: true

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -41,6 +41,43 @@ log_section() {
     echo -e "${BLUE}=== $1 ===${NC}"
 }
 
+# Dump every signal that diagnoses a failed helm install / pod-not-ready.
+# Without a release selector, dumps the entire test namespace — used
+# from the trap on script-exit so a 5m timeout on the StatefulSet no
+# longer prints just "InProgress, Ready: 0/1". kubectl describe +
+# events + pod logs land in the CI log alongside the error.
+dump_failure_diagnostics() {
+    local selector_args=()
+    if [[ -n "${1:-}" ]]; then
+        selector_args=(-l "app.kubernetes.io/instance=$1")
+        log_warn "Dumping cluster diagnostics for release '$1'..."
+    else
+        log_warn "Dumping cluster diagnostics for namespace '$NAMESPACE'..."
+    fi
+    echo "--- pods ---"
+    kubectl get pods -n "$NAMESPACE" "${selector_args[@]}" -o wide || true
+    echo "--- pvcs ---"
+    kubectl get pvc -n "$NAMESPACE" || true
+    echo "--- events (last 30, by lastTimestamp) ---"
+    kubectl get events -n "$NAMESPACE" --sort-by=.lastTimestamp 2>/dev/null | tail -30 || true
+    echo "--- describe pods ---"
+    kubectl describe pods -n "$NAMESPACE" "${selector_args[@]}" 2>/dev/null \
+        | sed -n '1,300p' || true
+    echo "--- logs (current container) ---"
+    kubectl logs -n "$NAMESPACE" "${selector_args[@]}" \
+        --all-containers=true --tail=200 --prefix=true 2>/dev/null || true
+    echo "--- logs (previous container, if any) ---"
+    kubectl logs -n "$NAMESPACE" "${selector_args[@]}" \
+        --all-containers=true --tail=200 --previous --prefix=true 2>/dev/null || true
+}
+
+# Install the failure-diagnostic dump as an ERR trap so EVERY helm
+# install / kubectl wait failure produces describe + logs alongside
+# the cryptic "context deadline exceeded" message. Without this the
+# integration suite was silently broken for a month before anyone
+# could see why.
+trap 'rc=$?; if [[ $rc -ne 0 && -n "${NAMESPACE:-}" ]]; then dump_failure_diagnostics; fi; exit $rc' ERR
+
 show_usage() {
     cat <<EOF
 Usage: $0 [OPTIONS]
@@ -262,7 +299,7 @@ test_default_deployment() {
     helm install test-default "$CHART_PATH" \
         -f "$CHART_PATH/test-values/default-values.yaml" \
         -n "$NAMESPACE" \
-        --wait --timeout=3m
+        --wait --timeout=5m
 
     # Wait for pods to be ready
     kubectl wait --for=condition=ready pod \
@@ -305,7 +342,7 @@ test_ingress_deployment() {
     helm install test-ingress "$CHART_PATH" \
         -f "$CHART_PATH/test-values/with-ingress-values.yaml" \
         -n "$NAMESPACE" \
-        --wait --timeout=3m
+        --wait --timeout=5m
 
     # Wait for pods to be ready
     kubectl wait --for=condition=ready pod \
@@ -339,7 +376,7 @@ test_postgres_deployment() {
     if ! helm install test-postgres "$CHART_PATH" \
         -f "$CHART_PATH/test-values/with-postgres-values.yaml" \
         -n "$NAMESPACE" \
-        --wait --timeout=3m; then
+        --wait --timeout=5m; then
         log_error "Helm install failed"
         log_info "Getting pod status:"
         kubectl get pods -n "$NAMESPACE" -o wide || true
@@ -414,7 +451,7 @@ test_persistence_deployment() {
     if helm install test-persist "$CHART_PATH" \
         -f "$CHART_PATH/test-values/with-persistence-values.yaml" \
         -n "$NAMESPACE" \
-        --wait --timeout=3m; then
+        --wait --timeout=5m; then
         log_info "Helm install succeeded"
     else
         log_error "Helm install failed"
@@ -547,7 +584,7 @@ test_production_like_deployment() {
     helm install test-production "$CHART_PATH" \
         -f "$CHART_PATH/test-values/production-like-values.yaml" \
         -n "$NAMESPACE" \
-        --wait --timeout=3m
+        --wait --timeout=5m
 
     # Debug: Check pod and PVC status immediately after install
     log_info "Checking pod and PVC status after install..."
@@ -626,13 +663,13 @@ test_upgrade_scenarios() {
     helm install upgrade-test "$CHART_PATH" \
         -f "$CHART_PATH/test-values/default-values.yaml" \
         -n "$NAMESPACE" \
-        --wait --timeout=3m
+        --wait --timeout=5m
 
     # Upgrade with ingress enabled
     helm upgrade upgrade-test "$CHART_PATH" \
         -f "$CHART_PATH/test-values/with-ingress-values.yaml" \
         -n "$NAMESPACE" \
-        --wait --timeout=3m
+        --wait --timeout=5m
 
     # Verify upgrade worked
     kubectl wait --for=condition=ready pod \


### PR DESCRIPTION
## Summary

Add Helm support for the standalone `oxy worker` fleet introduced in oxy-hq/oxygen-internal#2409 (`feat/worker-fleet-separation`). The split fleet lets HTTP frontends and queue workers scale independently against the same Postgres.

- `worker.enabled: false` by default — existing deployments are zero-impact on upgrade.
- New worker resources (when `worker.enabled: true`):
  - `Deployment/{release}-oxy-app-worker` running `oxy worker --health-port 8081 [--skip-migrations]`
  - `Service/{release}-oxy-app-worker` (ClusterIP on the health port — workers are driven by Postgres `LISTEN/NOTIFY`, not HTTP)
  - `PodDisruptionBudget/{release}-oxy-app-worker-pdb` (`minAvailable: 1`)
  - `HorizontalPodAutoscaler/{release}-oxy-app-worker-hpa` (off by default; renders as an `External` metric named `oxy_agentic_task_queue_depth` when enabled)
- New HTTP-side toggle: `appServer.disableInprocessWorkers` appends `--no-workers` to `oxy serve` and sets `OXY_DISABLE_INPROCESS_WORKERS=1`. Required on the HTTP StatefulSet whenever a worker fleet is handling agentic execution.
- Operator guide at `charts/oxy-app/docs/worker-fleet.md` covers the topology, HPA wiring (Prometheus + `prometheus-postgres-exporter` against `SELECT count(*) FROM agentic_task_queue WHERE queue_status='queued'`), and the `--skip-migrations` rationale (HTTP StatefulSet is the canonical migrator).
- Bumps `oxy-app` chart version `0.4.10 → 0.5.0`.

## Operational shape

```text
+--------------------+         +--------------------+
| oxy serve          |         | oxy worker         |
| --no-workers       |         | --health-port 8081 |
| (StatefulSet)      |         | (Deployment xN)    |
+---------+----------+         +---------+----------+
          |                              |
          +----------+ Postgres +--------+
                     |
              agentic_task_queue
```

Both fleets share the same `OXY_DATABASE_URL`. The durable transport's `SELECT ... FOR UPDATE SKIP LOCKED` claim is the only coordination surface; HTTP and workers cannot race a task.

## Defaults / safety

- `terminationGracePeriodSeconds: 40` on the worker pod (drain budget is ~35s per `internal-docs/worker-fleet.md`).
- `worker.skipMigrations: true` by default so a fleet rollout doesn't race migrations across N replicas — the HTTP StatefulSet runs them. Flip to false (and run `oxy migrate` separately) if you'd rather externalize migrations.
- Worker pods inherit `externalSecrets.envSecretNames` / `fileSecrets` (toggle via `worker.inheritExternalSecrets`) so they see the same DB / LLM keys as the HTTP fleet.
- HPA defaults to disabled. Custom external metric `oxy_agentic_task_queue_depth` (override via `worker.hpa.metricName`) plus an optional CPU fallback when `worker.hpa.cpuUtilization > 0`.

## Files

- `charts/oxy-app/templates/worker-deployment.yaml` (new)
- `charts/oxy-app/templates/worker-service.yaml` (new)
- `charts/oxy-app/templates/worker-pdb.yaml` (new)
- `charts/oxy-app/templates/worker-hpa.yaml` (new)
- `charts/oxy-app/templates/statefulset.yaml` (`--no-workers` + env wiring)
- `charts/oxy-app/values.yaml` (`appServer.*`, `worker.*`)
- `charts/oxy-app/Chart.yaml` (0.4.10 → 0.5.0)
- `charts/oxy-app/docs/worker-fleet.md` (new)
- `charts/oxy-app/README.md` (pointer to the new doc)
- `charts/oxy-app/tests/worker_test.yaml` (new)
- `charts/oxy-app/tests/worker_disabled_test.yaml` (new)
- `charts/oxy-app/tests/no_workers_flag_test.yaml` (new)

## Test plan

- [x] `helm lint charts/oxy-app` — clean (only the pre-existing icon INFO).
- [x] `helm template ...` with chart defaults — renders the same 4 resources as before (zero-impact upgrade).
- [x] `helm template ... --set worker.enabled=true` — renders 7 resources (adds Deployment + worker Service + worker PDB).
- [x] `helm template ... --set worker.enabled=true --set worker.hpa.enabled=true` — adds the HPA (8 total).
- [x] `helm template ... --set appServer.disableInprocessWorkers=true` — HTTP StatefulSet picks up `--no-workers` + `OXY_DISABLE_INPROCESS_WORKERS=1`.
- [x] `helm unittest charts/oxy-app -f "tests/**/*_test.yaml"` — 190/190 tests pass (156 existing + 34 new).
- [x] `ct lint --target-branch main --config ct.yaml --charts charts/oxy-app` — passes.
- [ ] CI: `helm-ci.yml` lint + unit + integration (kind) run against this branch.
- [ ] Soak: deploy `worker.enabled=true` + `appServer.disableInprocessWorkers=true` against a real Postgres and confirm worker `/readyz` flips during drain.

## Punted / known limitations (intentional first cut)

Mirroring `internal-docs/worker-fleet.md`:

- No dedicated `oxy migrate` Helm hook / Job — HTTP StatefulSet is the migrator.
- Recovery loop on the standalone worker is reaper-pre-pass only; cloud-mode multi-workspace stranded-run replay still requires at least one HTTP pod with in-process workers.
- No `ServiceMonitor`. The worker Service exposes the health port; add a `ServiceMonitor` out-of-band if you scrape `/healthz` / `/readyz`.
- HPA needs you to wire `prometheus-postgres-exporter` + your external-metrics adapter; the chart describes the metric but does not deploy the pipeline.

Refs: oxy-hq/oxygen-internal#2409