### PR TITLE
feat(oxy-app): stateless oxy-serve fleet for HA split (opt-in)

### DIFF
--- a/charts/oxy-app/Chart.yaml
+++ b/charts/oxy-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oxy-app
 description: A Helm chart for Oxy application deployment on kubernetes
 type: application
-version: 0.5.1
+version: 0.6.0
 appVersion: "0.5.49"
 keywords:
   - oxy

--- a/charts/oxy-app/templates/ingress.yaml
+++ b/charts/oxy-app/templates/ingress.yaml
@@ -1,7 +1,10 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "oxy-app.fullname" . -}}
 {{- $svcName := default (include "oxy-app.fullname" .) .Values.service.name -}}
+{{- $serveSvcName := printf "%s-serve" $fullName -}}
 {{- $root := . -}}
+{{- $serveEnabled := .Values.serveFleet.enabled -}}
+{{- $servePaths := default (list) .Values.serveFleet.ingressPaths -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -25,6 +28,26 @@ spec:
     - host: {{ $host.host | quote }}
       http:
         paths:
+          {{- /*
+            HA split routing. When `serveFleet.enabled: true`, the chart
+            renders one Ingress rule per path in `serveFleet.ingressPaths`
+            FIRST (more specific), pointing them at the stateless
+            oxy-serve Service. The catch-all path below then routes
+            everything else to the singleton StatefulSet (oxy-ide). Path
+            matching is order-dependent in most ingress controllers; we
+            list the specific paths before the catch-all explicitly.
+          */}}
+          {{- if $serveEnabled }}
+          {{- range $servePaths }}
+          - path: {{ . | quote }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serveSvcName }}
+                port:
+                  number: {{ $root.Values.serveFleet.service.port }}
+          {{- end }}
+          {{- end }}
           {{- if $host.paths }}
           {{- range $p := $host.paths }}
           - path: {{ $p.path | default $.Values.ingress.path | quote }}

--- a/charts/oxy-app/templates/serve-deployment.yaml
+++ b/charts/oxy-app/templates/serve-deployment.yaml
@@ -4,13 +4,21 @@ Stateless oxy-serve fleet — see oxygen-internal `internal-docs/2026-06-06-comp
 and the simplification doc at `2026-06-10-compile-boundary-simplification.md`.
 
 This Deployment serves Postgres-backed reads (customer-apps, external API,
-admin, chat list, and the Slice 4 runtime read paths as their per-surface
-`compile_*_use_postgres` flags flip on). No PVC, no workspace files — the
-StatefulSet remains the singleton owner of working copies.
+admin, chat list, and the runtime read paths — apps, procedures, agents,
+semantic). The compile boundary is always-on (no per-surface flags); each
+read falls back to the filesystem only when the workspace isn't compiled —
+which a stateless replica can't do, so a workspace must be compiled before
+this fleet serves it. No PVC, no workspace files — the StatefulSet remains
+the singleton owner of working copies.
 
 Both fleets share the SAME Postgres (`OXY_DATABASE_URL`). The StatefulSet
 is the canonical migrator; oxy-serve pods skip migrations and assume the
 schema is already in place.
+
+IMPORTANT: compiles only run on a node that has the working copy AND drives
+the global task queue — i.e. the StatefulSet with `OXY_INPROC_GLOBAL_WORKER=1`.
+If nothing drives compiles, this fleet has no promoted revisions to serve.
+See the `serveFleet` notes in values.yaml.
 */}}
 {{- $serveImageRepo := default .Values.app.image .Values.serveFleet.image.repository -}}
 {{- $serveImageTag := default (default .Chart.AppVersion .Values.app.imageTag) .Values.serveFleet.image.tag -}}
@@ -102,6 +110,12 @@ spec:
               value: "1"
             - name: OXY_SKIP_MIGRATIONS
               value: "1"
+            # Compile-boundary S3 reads (semantic blobs + DuckDB mirror). Must
+            # match the bucket the StatefulSet compile writer uploads to.
+            {{- if .Values.compileBoundary.blobS3Bucket }}
+            - name: OXY_COMPILE_BLOB_S3_BUCKET
+              value: {{ .Values.compileBoundary.blobS3Bucket | quote }}
+            {{- end }}
             {{- range $k, $v := .Values.serveFleet.env }}
             - name: {{ $k | quote }}
               value: {{ $v | quote }}

--- a/charts/oxy-app/templates/serve-deployment.yaml
+++ b/charts/oxy-app/templates/serve-deployment.yaml
@@ -1,0 +1,115 @@
+{{- if .Values.serveFleet.enabled }}
+{{- /*
+Stateless oxy-serve fleet — see oxygen-internal `internal-docs/2026-06-06-compile-boundary-design.md`
+and the simplification doc at `2026-06-10-compile-boundary-simplification.md`.
+
+This Deployment serves Postgres-backed reads (customer-apps, external API,
+admin, chat list, and the Slice 4 runtime read paths as their per-surface
+`compile_*_use_postgres` flags flip on). No PVC, no workspace files — the
+StatefulSet remains the singleton owner of working copies.
+
+Both fleets share the SAME Postgres (`OXY_DATABASE_URL`). The StatefulSet
+is the canonical migrator; oxy-serve pods skip migrations and assume the
+schema is already in place.
+*/}}
+{{- $serveImageRepo := default .Values.app.image .Values.serveFleet.image.repository -}}
+{{- $serveImageTag := default (default .Chart.AppVersion .Values.app.imageTag) .Values.serveFleet.image.tag -}}
+{{- $serveImagePullPolicy := default .Values.app.imagePullPolicy .Values.serveFleet.image.pullPolicy -}}
+{{- $serveSa := default (include "oxy-app.serviceAccountName" .) .Values.serveFleet.serviceAccountName -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "oxy-app.fullname" . }}-serve
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oxy-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: serve
+spec:
+  replicas: {{ .Values.serveFleet.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "oxy-app.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: serve
+  strategy:
+    {{- toYaml .Values.serveFleet.strategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "oxy-app.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: serve
+        {{- with .Values.serveFleet.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.serveFleet.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if ne $serveSa "" }}
+      serviceAccountName: {{ $serveSa | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.serveFleet.terminationGracePeriodSeconds }}
+      {{- with .Values.serveFleet.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serveFleet.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serveFleet.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serveFleet.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: serve
+          image: "{{ $serveImageRepo }}:{{ $serveImageTag }}"
+          imagePullPolicy: {{ $serveImagePullPolicy }}
+          {{- with .Values.serveFleet.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.serveFleet.command (gt (len .Values.serveFleet.command) 0) }}
+          command:
+            {{- range .Values.serveFleet.command }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- else }}
+          # Default: HTTP-only, no in-process workers, no workspace FS.
+          # Migrations are owned by the StatefulSet.
+          command:
+            - "sh"
+            - "-c"
+            - "exec oxy serve --no-workers"
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: OXY_DISABLE_INPROCESS_WORKERS
+              value: "1"
+            - name: OXY_SKIP_MIGRATIONS
+              value: "1"
+            {{- range $k, $v := .Values.serveFleet.env }}
+            - name: {{ $k | quote }}
+              value: {{ $v | quote }}
+            {{- end }}
+            {{- with .Values.serveFleet.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.serveFleet.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.serveFleet.resources | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.serveFleet.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.serveFleet.readinessProbe | nindent 12 }}
+{{- end }}

--- a/charts/oxy-app/templates/serve-deployment.yaml
+++ b/charts/oxy-app/templates/serve-deployment.yaml
@@ -91,6 +91,13 @@ spec:
               containerPort: 3000
               protocol: TCP
           env:
+            # Role classification — oxygen-internal PR #2505 routing guardrail.
+            # Stateless fleet replica with no workspace volume mounted.
+            # FS-touching routes (IDE pages, file CRUD, git, compile,
+            # onboarding) 421 with X-Oxy-Required-Role: ide instead of
+            # silently 500ing.
+            - name: OXY_ROLE
+              value: "serve"
             - name: OXY_DISABLE_INPROCESS_WORKERS
               value: "1"
             - name: OXY_SKIP_MIGRATIONS

--- a/charts/oxy-app/templates/serve-pdb.yaml
+++ b/charts/oxy-app/templates/serve-pdb.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.serveFleet.enabled .Values.serveFleet.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "oxy-app.fullname" . }}-serve
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oxy-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: serve
+spec:
+  minAvailable: {{ .Values.serveFleet.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "oxy-app.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: serve
+{{- end }}

--- a/charts/oxy-app/templates/serve-service.yaml
+++ b/charts/oxy-app/templates/serve-service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.serveFleet.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "oxy-app.fullname" . }}-serve
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oxy-app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: serve
+  {{- with .Values.serveFleet.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.serveFleet.service.type }}
+  selector:
+    {{- include "oxy-app.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: serve
+  ports:
+    - name: http
+      port: {{ .Values.serveFleet.service.port }}
+      targetPort: {{ .Values.serveFleet.service.targetPort }}
+      protocol: TCP
+{{- end }}

--- a/charts/oxy-app/templates/statefulset.yaml
+++ b/charts/oxy-app/templates/statefulset.yaml
@@ -322,6 +322,13 @@ spec:
 
           # Environment Variables
           env:
+            # Role classification — oxygen-internal PR #2505 routing guardrail.
+            # IDE singleton: owns the workspace working copy + .git tree.
+            # Accepts every route (IdeOnly + FleetOk) on this pod. When
+            # serveFleet is enabled, the path-based ingress routes the
+            # write-heavy IDE surface here while stateless reads go to oxy-serve.
+            - name: OXY_ROLE
+              value: "ide"
             # State Directory Configuration
             {{- if and .Values.env.OXY_STATE_DIR (ne .Values.env.OXY_STATE_DIR "") }}
             - name: OXY_STATE_DIR

--- a/charts/oxy-app/templates/statefulset.yaml
+++ b/charts/oxy-app/templates/statefulset.yaml
@@ -346,6 +346,21 @@ spec:
               value: "1"
             {{- end }}
 
+            # Compile-boundary global driver: drive the Global task queue
+            # (incl. TaskSpec::Compile) in-process. The StatefulSet is the only
+            # node with the working copy, so compiles can ONLY run here. Inert
+            # under --no-workers, so gate on both.
+            {{- if and .Values.appServer.inprocGlobalWorker (not .Values.appServer.disableInprocessWorkers) }}
+            - name: OXY_INPROC_GLOBAL_WORKER
+              value: "1"
+            {{- end }}
+            # Compile-boundary S3 offload (semantic blobs + local-DuckDB mirror).
+            # This is the compile WRITER, so it needs the bucket to upload.
+            {{- if .Values.compileBoundary.blobS3Bucket }}
+            - name: OXY_COMPILE_BLOB_S3_BUCKET
+              value: {{ .Values.compileBoundary.blobS3Bucket | quote }}
+            {{- end }}
+
             # Database URL Configuration
             # Preference order (sqlite fallback intentionally omitted):
             # 1) Explicit value provided by caller via values.env.OXY_DATABASE_URL

--- a/charts/oxy-app/templates/worker-deployment.yaml
+++ b/charts/oxy-app/templates/worker-deployment.yaml
@@ -96,6 +96,12 @@ spec:
             # under this role because FleetOk routes are accepted by Worker.
             - name: OXY_ROLE
               value: "worker"
+            # Compile-boundary S3 reads: a worker executing an agentic run can
+            # read semantic blobs from S3, so it needs the same bucket.
+            {{- if .Values.compileBoundary.blobS3Bucket }}
+            - name: OXY_COMPILE_BLOB_S3_BUCKET
+              value: {{ .Values.compileBoundary.blobS3Bucket | quote }}
+            {{- end }}
             # Database URL Configuration — mirrors the HTTP StatefulSet
             # precedence so both fleets agree on the same Postgres.
             {{- if and .Values.env.OXY_DATABASE_URL (ne .Values.env.OXY_DATABASE_URL "") }}

--- a/charts/oxy-app/templates/worker-deployment.yaml
+++ b/charts/oxy-app/templates/worker-deployment.yaml
@@ -91,6 +91,11 @@ spec:
               containerPort: {{ .Values.worker.healthPort }}
               protocol: TCP
           env:
+            # Role classification — oxygen-internal PR #2505 routing guardrail.
+            # Queue drainer; no inbound customer HTTP. /healthz still works
+            # under this role because FleetOk routes are accepted by Worker.
+            - name: OXY_ROLE
+              value: "worker"
             # Database URL Configuration — mirrors the HTTP StatefulSet
             # precedence so both fleets agree on the same Postgres.
             {{- if and .Values.env.OXY_DATABASE_URL (ne .Values.env.OXY_DATABASE_URL "") }}

--- a/charts/oxy-app/values.yaml
+++ b/charts/oxy-app/values.yaml
@@ -32,6 +32,35 @@ appServer:
   # deployments are unaffected on upgrade.
   disableInprocessWorkers: false
 
+  # Drive the GLOBAL task queue (incl. TaskSpec::Compile) in-process on the
+  # StatefulSet by setting OXY_INPROC_GLOBAL_WORKER=1.
+  #
+  # REQUIRED for the compile boundary: a compile can only run on a node that
+  # has the working copy AND drives the global queue — that's the StatefulSet
+  # (oxy-ide). With this off, Compile tasks enqueue but never drain, no
+  # workspace promotes, and a stateless `serveFleet` 503s every request.
+  #
+  # Only effective when in-process workers are running (i.e. NOT
+  # `disableInprocessWorkers`); under `--no-workers` the StatefulSet can't
+  # drive compiles, and the standalone `oxy worker` fleet can't either (no
+  # working copy — per-worker clone-on-demand is a later phase). So to use the
+  # compile boundary today, keep `disableInprocessWorkers: false` and set this
+  # `true`. Default false so existing deployments are unaffected on upgrade.
+  inprocGlobalWorker: false
+
+# Compile-boundary cross-cutting config. The runtime serves workspace
+# definitions from Postgres (always-on, no feature flags); these knobs tune the
+# optional S3 offload. See oxygen-internal `internal-docs/compile-boundary.md`.
+compileBoundary:
+  # S3 bucket for (a) semantic view/topic blob offload and (b) the local-file
+  # DuckDB → S3 mirror. Injected as OXY_COMPILE_BLOB_S3_BUCKET on the
+  # StatefulSet (the compile WRITER), the serve fleet and the worker (READERS)
+  # — writer and readers must agree on the same bucket. Empty = disabled:
+  # semantic bodies stay in Postgres JSONB (works, just larger) and local-file
+  # DuckDB warehouses are NOT servable by the stateless fleet. The pod IAM role
+  # needs s3:PutObject (writer) / s3:GetObject (readers) on this bucket.
+  blobS3Bucket: ""
+
 # Ingress configuration
 # Enable and configure Kubernetes Ingress for the application.
 ingress:
@@ -531,9 +560,9 @@ pdb:
 # Topology when enabled:
 #   - oxy-ide (StatefulSet, replicas=1): IDE / files / git / compile
 #   - oxy-serve (Deployment, this stanza, replicas=N): everything that
-#     only needs Postgres — customer-apps, external API, chat, admin,
-#     and once `compile_*_use_postgres` per-surface flags are flipped on,
-#     also the runtime read paths (apps, procedures, agents, semantic).
+#     only needs Postgres — customer-apps, external API, chat, admin, and
+#     the runtime read paths (apps, procedures, agents, semantic). The
+#     compile boundary is always-on (no per-surface flags).
 #   - oxy-worker (Deployment, see `worker` stanza): TaskSpec consumers.
 #
 # Set `serveFleet.enabled: false` (default) to render no oxy-serve
@@ -543,8 +572,16 @@ pdb:
 # true`, the chart renders a SECOND Ingress entry that routes
 # `serveFleet.ingressPaths` to the oxy-serve Service. The default paths
 # list keeps IDE / files / git / compile on the StatefulSet and routes
-# everything else to oxy-serve — operators flip more paths over as the
-# Slice 4 per-surface flags ship.
+# everything else to oxy-serve.
+#
+# ── REQUIRED config for the compile boundary ───────────────────────────
+# The stateless fleet can ONLY serve a workspace that has been compiled (it
+# has no working copy to fall back to). So compiles MUST drain — set
+# `appServer.inprocGlobalWorker: true` (keep `disableInprocessWorkers: false`)
+# so the StatefulSet drives them. The `oxy worker` fleet does NOT compile (no
+# working copy; per-worker clone-on-demand is a later phase). For S3 offload +
+# DuckDB-on-fleet, set `compileBoundary.blobS3Bucket`. After deploy, compile
+# existing workspaces once via the admin "Compile all uncompiled" backfill.
 serveFleet:
   enabled: false
   # Number of stateless pods. HPA-friendly — these have no PVC, no in-
@@ -569,7 +606,8 @@ serveFleet:
     annotations: {}
   # Ingress path prefixes that should route to oxy-serve. Anything NOT
   # in this list keeps going to the singleton StatefulSet (oxy-ide).
-  # Adjust as more `compile_*_use_postgres` per-surface flags ship.
+  # Add the runtime read surfaces (e.g. /apps, agent/procedure runs) here
+  # once you've compiled + backfilled and verified the fleet serves them.
   ingressPaths:
     - /admin
     - /threads

--- a/charts/oxy-app/values.yaml
+++ b/charts/oxy-app/values.yaml
@@ -518,6 +518,120 @@ pdb:
 #   - Both point at the SAME Postgres (`OXY_DATABASE_URL`).
 #
 # Operational requirements live in oxygen-internal `internal-docs/worker-fleet.md`.
+
+# ---------------------------------------------------------------------------
+# Stateless `oxy-serve` fleet (HA split)
+# ---------------------------------------------------------------------------
+# Opt-in stateless HTTP Deployment that serves the compile-boundary read
+# paths (customer-apps, external API, runtime serving) without touching
+# the workspace filesystem. The existing StatefulSet stays as the
+# singleton `oxy-ide` that owns working copies + file CRUD + git ops +
+# the IDE Compile button. The two fleets share the same Postgres.
+#
+# Topology when enabled:
+#   - oxy-ide (StatefulSet, replicas=1): IDE / files / git / compile
+#   - oxy-serve (Deployment, this stanza, replicas=N): everything that
+#     only needs Postgres — customer-apps, external API, chat, admin,
+#     and once `compile_*_use_postgres` per-surface flags are flipped on,
+#     also the runtime read paths (apps, procedures, agents, semantic).
+#   - oxy-worker (Deployment, see `worker` stanza): TaskSpec consumers.
+#
+# Set `serveFleet.enabled: false` (default) to render no oxy-serve
+# resources and preserve existing single-StatefulSet behaviour.
+#
+# Ingress routing: when `serveFleet.enabled: true` AND `ingress.enabled:
+# true`, the chart renders a SECOND Ingress entry that routes
+# `serveFleet.ingressPaths` to the oxy-serve Service. The default paths
+# list keeps IDE / files / git / compile on the StatefulSet and routes
+# everything else to oxy-serve — operators flip more paths over as the
+# Slice 4 per-surface flags ship.
+serveFleet:
+  enabled: false
+  # Number of stateless pods. HPA-friendly — these have no PVC, no in-
+  # memory state to drain on rollout.
+  replicaCount: 2
+  # Image: inherits from .Values.app.image / .Values.app.imageTag when
+  # left empty. Override only when you intentionally want the serve
+  # fleet pinned to a different tag (e.g. canary).
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: ""
+  # Override the container command. When empty, the chart uses
+  #   exec oxy serve --no-workers
+  command: []
+  # Service surface. ClusterIP only — exposure happens via the chart's
+  # main Ingress when `ingress.enabled` is on.
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 3000
+    annotations: {}
+  # Ingress path prefixes that should route to oxy-serve. Anything NOT
+  # in this list keeps going to the singleton StatefulSet (oxy-ide).
+  # Adjust as more `compile_*_use_postgres` per-surface flags ship.
+  ingressPaths:
+    - /admin
+    - /threads
+    - /workspaces
+    - /external/api
+    - /auth
+    - /api/auth
+    - /webhooks
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1
+      memory: 1Gi
+  # Container env. The chart injects OXY_DATABASE_URL automatically from
+  # the shared Postgres config (same as the StatefulSet).
+  env: {}
+  extraEnv: []
+  extraEnvFrom: []
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 3000
+    initialDelaySeconds: 15
+    periodSeconds: 10
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: 3000
+    initialDelaySeconds: 5
+    periodSeconds: 5
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+  podAnnotations: {}
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+  # By default, prefer to spread oxy-serve pods across nodes so a node
+  # failure can only take one replica at a time.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: serve
+  serviceAccountName: ""
+  securityContext: {}
+  containerSecurityContext: {}
+  terminationGracePeriodSeconds: 30
+  # Strategy: rolling update with at-least-one alive. These are stateless
+  # so we can be aggressive about maxSurge to speed cutover.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: "50%"
+
 worker:
   enabled: false
   # Number of worker pods. Scale independently of the HTTP fleet.


### PR DESCRIPTION
Adds a second HTTP fleet (Deployment, stateless) alongside the existing
singleton StatefulSet (working-copy owner). When `serveFleet.enabled:
true`, the chart renders a `-serve` Deployment + Service + PDB and the
Ingress prepends path-based rules routing the configured prefixes to
the stateless fleet. The catch-all path continues to land on the
StatefulSet (oxy-ide).

Topology when serveFleet is on:
  - oxy-ide   = StatefulSet (replicas=1, PVC):
                IDE / files / git / compile / runtime YAML reads
  - oxy-serve = Deployment (replicas=N, no PVC):
                customer-apps + external API + admin + chat list +
                Slice 4 routes as their per-surface
                `compile_*_use_postgres` flags ship
  - oxy-worker= Deployment (existing worker.enabled stanza)

Default `serveFleet.enabled: false` so existing deployments upgrade
with zero impact. Verified via `helm lint` + `helm template` that
disabled mode renders identical resources to before.

Default `serveFleet.ingressPaths` is the conservative starting set
that's safe today (admin, threads, workspaces, external/api, auth,
webhooks). Operators extend the list as Slice 4 per-surface flags
flip on (`compile_apps_use_postgres` → add `/apps`, etc.).

oxy-serve pods set `OXY_SKIP_MIGRATIONS=1` and `OXY_DISABLE_INPROCESS_WORKERS=1`
— migrations stay owned by the StatefulSet (canonical migrator) and
workers stay owned by the worker fleet.

The Compile boundary work shipping in oxygen-internal#2460
(commit feat/compile-boundary-end-to-end) is the precondition for
moving runtime read paths to oxy-serve — the per-surface feature flags
in that PR are what controls when each path becomes safe to route here.