### PR TITLE
fix(oxy-app): make opt-in serveFleet actually functional (0.6.1)

### DIFF
--- a/charts/oxy-app/Chart.yaml
+++ b/charts/oxy-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oxy-app
 description: A Helm chart for Oxy application deployment on kubernetes
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: "0.5.49"
 keywords:
   - oxy

--- a/charts/oxy-app/templates/serve-deployment.yaml
+++ b/charts/oxy-app/templates/serve-deployment.yaml
@@ -106,16 +106,81 @@ spec:
             # silently 500ing.
             - name: OXY_ROLE
               value: "serve"
+            # Stateless: never run in-process workers, never drive the global
+            # task queue. Compiles run ONLY on the StatefulSet (the node with
+            # the working copy). OXY_INPROC_GLOBAL_WORKER is deliberately
+            # stripped from the shared-env passthrough below so it can't leak
+            # in and turn a serve replica into a working-copy-less compile
+            # driver — --no-workers makes it inert, but we don't rely on that.
             - name: OXY_DISABLE_INPROCESS_WORKERS
               value: "1"
             - name: OXY_SKIP_MIGRATIONS
               value: "1"
+            # Ephemeral scratch (result cache, generated charts) on an emptyDir
+            # mount — there is no PVC here. Skipped from the shared-env
+            # passthrough because the StatefulSet's OXY_STATE_DIR points at the
+            # /workspace PVC, which this fleet doesn't mount.
+            - name: OXY_STATE_DIR
+              value: {{ .Values.serveFleet.stateDir | quote }}
             # Compile-boundary S3 reads (semantic blobs + DuckDB mirror). Must
             # match the bucket the StatefulSet compile writer uploads to.
             {{- if .Values.compileBoundary.blobS3Bucket }}
             - name: OXY_COMPILE_BLOB_S3_BUCKET
               value: {{ .Values.compileBoundary.blobS3Bucket | quote }}
             {{- end }}
+
+            # Database URL — the SAME shared Postgres as the StatefulSet, same
+            # precedence (compiled *_definitions rows live here; serving them is
+            # the entire purpose of the stateless fleet). Mirrors the injection
+            # in statefulset.yaml.
+            {{- if and .Values.env.OXY_DATABASE_URL (ne .Values.env.OXY_DATABASE_URL "") }}
+            - name: OXY_DATABASE_URL
+              value: {{ .Values.env.OXY_DATABASE_URL | quote }}
+            {{- else if and .Values.database.external.enabled (ne .Values.database.external.connectionString "") }}
+            - name: OXY_DATABASE_URL
+              value: {{ .Values.database.external.connectionString | quote }}
+            {{- else if .Values.database.external.enabled }}
+            - name: OXY_DATABASE_URL
+              value: {{ printf "postgresql://%s:%s@%s:%v/%s"
+                .Values.database.external.user
+                .Values.database.external.password
+                .Values.database.external.host
+                .Values.database.external.port
+                .Values.database.external.database | quote }}
+            {{- else if .Values.database.postgres.enabled }}
+            - name: OXY_DATABASE_URL
+              {{- $pgHost := "" }}
+              {{- if .Values.postgres.fullnameOverride }}
+                {{- $pgHost = printf "%s.%s.svc.cluster.local" .Values.postgres.fullnameOverride .Release.Namespace }}
+              {{- else if .Values.database.postgres.host }}
+                {{- $pgHost = .Values.database.postgres.host }}
+              {{- else }}
+                {{- $pgHost = printf "%s-postgres.%s.svc.cluster.local" .Release.Name .Release.Namespace }}
+              {{- end }}
+              value: {{ printf "postgresql://%s:%s@%s:%v/%s"
+                (default "postgres" .Values.postgres.userDatabase.user.value)
+                (default "postgres" .Values.postgres.userDatabase.password.value)
+                $pgHost
+                .Values.database.postgres.port
+                (default "postgres" .Values.postgres.userDatabase.name.value) | quote }}
+            {{- end }}
+
+            # Shared env passthrough (warehouse creds, DUCKLAKE_*, observability,
+            # Slack, magic-link, customer-apps bucket, …) — same source as the
+            # StatefulSet. Three keys are intentionally skipped:
+            #   OXY_STATE_DIR            → PVC path that doesn't exist here (set above)
+            #   OXY_DATABASE_URL         → injected with precedence above
+            #   OXY_INPROC_GLOBAL_WORKER → fleet must never drive the global queue
+            {{- range $key, $value := .Values.env }}
+            {{- if and (ne $key "OXY_STATE_DIR") (ne $key "OXY_DATABASE_URL") (ne $key "OXY_INPROC_GLOBAL_WORKER") }}
+            {{- if ne $value "" }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+
+            # Per-fleet overrides win over shared env (listed last).
             {{- range $k, $v := .Values.serveFleet.env }}
             - name: {{ $k | quote }}
               value: {{ $v | quote }}
@@ -123,14 +188,36 @@ spec:
             {{- with .Values.serveFleet.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.serveFleet.extraEnvFrom }}
+
+          # Shared configMap + external secrets (LLM keys, GitHub, Airhouse) —
+          # same envFrom as the StatefulSet so agent runs, auth, and
+          # integrations work on the fleet. Plus any serveFleet-specific envFrom.
+          {{- if or .Values.configMap.enabled (gt (len .Values.externalSecrets.envSecretNames) 0) .Values.serveFleet.extraEnvFrom }}
           envFrom:
+            {{- if .Values.configMap.enabled }}
+            - configMapRef:
+                name: {{ include "oxy-app.fullname" . }}-config
+            {{- end }}
+            {{- range .Values.externalSecrets.envSecretNames }}
+            - secretRef:
+                name: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.serveFleet.extraEnvFrom }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
+          volumeMounts:
+            - name: oxy-serve-state
+              mountPath: {{ .Values.serveFleet.stateDir | quote }}
           resources:
             {{- toYaml .Values.serveFleet.resources | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.serveFleet.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.serveFleet.readinessProbe | nindent 12 }}
+      volumes:
+        # Ephemeral scratch backing OXY_STATE_DIR (result cache, charts).
+        # Per-pod, discarded on restart — nothing here is a source of truth.
+        - name: oxy-serve-state
+          emptyDir: {}
 {{- end }}

--- a/charts/oxy-app/templates/service.yaml
+++ b/charts/oxy-app/templates/service.yaml
@@ -8,6 +8,17 @@ metadata:
 spec:
   selector:
     {{- include "oxy-app.selectorLabels" . | nindent 4 }}
+    {{- /*
+      HA split: when the stateless serve fleet is enabled, pin this Service
+      (the ingress catch-all `/` backend) to the StatefulSet singleton via its
+      component=ide anchor. Without this, the bare name+instance selector also
+      matches the serve (component=serve) and worker (component=worker) pods,
+      so IDE/editing traffic would round-robin onto pods that 421 or don't
+      serve it. Gated so serveFleet-off deployments keep the current selector.
+    */}}
+    {{- if .Values.serveFleet.enabled }}
+    app.kubernetes.io/component: ide
+    {{- end }}
   ports:
   - port: {{ .Values.service.port }}
     targetPort: {{ .Values.service.targetPort }}

--- a/charts/oxy-app/templates/statefulset.yaml
+++ b/charts/oxy-app/templates/statefulset.yaml
@@ -35,6 +35,18 @@ spec:
       labels:
         {{- include "oxy-app.selectorLabels" . | nindent 8 }}
         version: v1
+        {{- /*
+          HA-split routing anchor. When serveFleet is enabled, the main Service
+          selects on this label so the catch-all `/` route reaches ONLY this
+          singleton (which owns the working copy + drives compiles) — not the
+          stateless serve pods (component=serve) nor the worker pods
+          (component=worker), both of which also carry the bare
+          name+instance selectorLabels. Gated so serveFleet-off deployments
+          keep their exact current pod template (no rollout on upgrade).
+        */}}
+        {{- if .Values.serveFleet.enabled }}
+        app.kubernetes.io/component: ide
+        {{- end }}
       {{- if .Values.otelCollector.enabled }}
       annotations:
         checksum/otel-config: {{ include (print $.Template.BasePath "/otel-configmap.yaml") . | sha256sum }}

--- a/charts/oxy-app/values.yaml
+++ b/charts/oxy-app/values.yaml
@@ -623,20 +623,33 @@ serveFleet:
     limits:
       cpu: 1
       memory: 1Gi
-  # Container env. The chart injects OXY_DATABASE_URL automatically from
-  # the shared Postgres config (same as the StatefulSet).
+  # Ephemeral state dir for the stateless fleet (no PVC). Backed by an
+  # emptyDir mount; holds the parquet result cache + generated charts —
+  # per-pod scratch that's safe to lose on restart.
+  stateDir: /var/lib/oxy
+  # Container env. The chart injects OXY_DATABASE_URL + the shared `.Values.env`
+  # (minus OXY_STATE_DIR / OXY_DATABASE_URL / OXY_INPROC_GLOBAL_WORKER) + the
+  # externalSecrets envFrom automatically — same Postgres + secrets as the
+  # StatefulSet. Use this map only for serve-fleet-specific overrides.
   env: {}
   extraEnv: []
   extraEnvFrom: []
+  # Probes hit the REAL endpoints, which live under the /api nest
+  # (public.rs → nested at /api). /api/live is an unconditional 200 (process
+  # up — won't crashloop on a transient DB blip); /api/ready returns 503 unless
+  # Postgres is reachable, so a replica that can't read compiled definitions is
+  # pulled from the Service endpoints instead of serving 500s. NB: top-level
+  # /health and /ready do NOT exist — they fall through to the SPA and would
+  # mask an unhealthy pod with a 200.
   livenessProbe:
     httpGet:
-      path: /health
+      path: /api/live
       port: 3000
     initialDelaySeconds: 15
     periodSeconds: 10
   readinessProbe:
     httpGet:
-      path: /ready
+      path: /api/ready
       port: 3000
     initialDelaySeconds: 5
     periodSeconds: 5


### PR DESCRIPTION
## Why

The `serveFleet` opt-in shipped in 0.6.0 (#10) but **could not serve a single request**. The Deployment injected only `OXY_ROLE` / `OXY_SKIP_MIGRATIONS` + the compile bucket — **no `OXY_DATABASE_URL`, no shared `.Values.env`, no `externalSecrets`** — so a replica had no Postgres connection, no warehouse creds, and no LLM keys. The `values.yaml` even *documented* "the chart injects OXY_DATABASE_URL automatically," but the template never did. On top of that the main `Service` selector over-selected pods. This PR makes the stateless fleet a real peer of the StatefulSet.

Part of the compile-boundary rollout (oxygen-internal #2505). Enabling it on an environment lives in the infra repo; this PR is chart-only and **gated** so nothing changes for serveFleet-off deployments.

## What

**`serve-deployment.yaml`**
- Inject `OXY_DATABASE_URL` with the **same precedence** as the StatefulSet (`.Values.env` → external connectionString → external fields → postgres subchart).
- Pass through the shared `.Values.env`, and add the `externalSecrets` + configMap `envFrom`.
- **Strip three node-role keys** from the passthrough — `OXY_STATE_DIR` (PVC path that doesn't exist here), `OXY_DATABASE_URL` (injected above), and `OXY_INPROC_GLOBAL_WORKER` — so a serve replica can **never** drive the global queue / compile without a working copy.
- Back `OXY_STATE_DIR` with an `emptyDir` (no PVC on the fleet).
- Point probes at the **real** endpoints: `/api/live` (liveness) + `/api/ready` (readiness, gates on DB reachability). Top-level `/health` / `/ready` don't exist — they fall through to the SPA and would mask an unhealthy pod with a 200.

**`service.yaml` + `statefulset.yaml`**
- When `serveFleet.enabled`, label the StatefulSet pods `component: ide` and pin the main `Service` selector to it. Without this, the bare `name+instance` selector also matches the serve (`component: serve`) and worker (`component: worker`) pods, so the ingress catch-all `/` would round-robin IDE/editing traffic onto pods that 421 or don't serve it.
- **Gated** on `serveFleet.enabled` → serveFleet-off deployments render **byte-for-byte unchanged** (no pod-template change, no rollout).

**`Chart.yaml`**: 0.6.0 → **0.6.1**.

## Validation

- `helm lint` clean.
- Rendered against real env values (serveFleet on): serve Deployment carries `OXY_DATABASE_URL` + the full shared env + 4 `secretRef`s + emptyDir; `OXY_INPROC_GLOBAL_WORKER` absent; StatefulSet **keeps** `OXY_INPROC_GLOBAL_WORKER=1` (still drives compiles); main Service selector = `component: ide`; ingress splits the curated FleetOk prefixes → `*-serve`, catch-all `/` → StatefulSet.
- Rendered with serveFleet **off**: zero `component: ide`, no serve resources — confirms the gate.

## Note

Publishing 0.6.1 (tag `oxy-app-0.6.1`) must land before any environment pins its `chartRevision` to `0.6.1`.