### PR TITLE
feat(oxy-app): inverse ingress routing — chart-default IdeOnly list (0.6.2)

### DIFF
--- a/charts/oxy-app/Chart.yaml
+++ b/charts/oxy-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oxy-app
 description: A Helm chart for Oxy application deployment on kubernetes
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: "0.5.49"
 keywords:
   - oxy

--- a/charts/oxy-app/templates/ingress.yaml
+++ b/charts/oxy-app/templates/ingress.yaml
@@ -5,6 +5,17 @@
 {{- $root := . -}}
 {{- $serveEnabled := .Values.serveFleet.enabled -}}
 {{- $servePaths := default (list) .Values.serveFleet.ingressPaths -}}
+{{- $ideRoutes := default (list) .Values.ideRoutes -}}
+{{- /*
+  Inverse routing kicks in when serveFleet.enabled is true AND
+  ideRoutes is non-empty: the catch-all flips to the serve fleet, and
+  only the listed IdeOnly patterns peel off to the singleton StatefulSet
+  (oxy-ide). Otherwise the chart stays in the legacy additive shape
+  (catch-all → StatefulSet, serveFleet.ingressPaths peeled to serve).
+  Default ideRoutes ships pre-populated in values.yaml so the workload
+  does not need to track the role-manifest list.
+*/}}
+{{- $inverseMode := and $serveEnabled (gt (len $ideRoutes) 0) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -29,15 +40,37 @@ spec:
       http:
         paths:
           {{- /*
-            HA split routing. When `serveFleet.enabled: true`, the chart
-            renders one Ingress rule per path in `serveFleet.ingressPaths`
-            FIRST (more specific), pointing them at the stateless
-            oxy-serve Service. The catch-all path below then routes
-            everything else to the singleton StatefulSet (oxy-ide). Path
-            matching is order-dependent in most ingress controllers; we
-            list the specific paths before the catch-all explicitly.
+            (1) IdeOnly patterns. Most specific, listed first. Only
+            rendered in inverse mode — when the serve fleet is off,
+            everything already lands on the StatefulSet via the
+            catch-all, so emitting these entries would create 15
+            redundant ALB rules.
+            Default pathType ImplementationSpecific is what the AWS ALB
+            Ingress Controller passes through unmodified, so mid-segment
+            wildcards (the asterisk in /api/WORKSPACE/files) reach the
+            ALB as a native path pattern. Override per-entry with
+            pathType Prefix for left-anchored paths.
           */}}
-          {{- if $serveEnabled }}
+          {{- if $inverseMode }}
+          {{- range $r := $ideRoutes }}
+          - path: {{ $r.path | quote }}
+            pathType: {{ default "ImplementationSpecific" $r.pathType }}
+            backend:
+              service:
+                name: {{ $svcName }}
+                port:
+                  number: {{ $root.Values.service.port }}
+          {{- end }}
+          {{- end }}
+          {{- /*
+            (2) Legacy additive list (serveFleet.ingressPaths). Only
+            useful in legacy mode where the catch-all goes to the
+            StatefulSet — these prefixes peel specific paths to the
+            serve fleet. In inverse mode the catch-all already lands
+            on the serve fleet, so re-emitting these would create
+            duplicate ALB rules; skip them.
+          */}}
+          {{- if and $serveEnabled (not $inverseMode) }}
           {{- range $servePaths }}
           - path: {{ . | quote }}
             pathType: Prefix
@@ -48,7 +81,21 @@ spec:
                   number: {{ $root.Values.serveFleet.service.port }}
           {{- end }}
           {{- end }}
-          {{- if $host.paths }}
+          {{- /*
+            (3) Catch-all. Inverse mode points it at the serve fleet;
+            otherwise it stays on the StatefulSet (legacy behavior,
+            preserved when ideRoutes is empty so existing deployments
+            upgrade byte-identical).
+          */}}
+          {{- if $inverseMode }}
+          - path: {{ $.Values.ingress.path | quote }}
+            pathType: {{ $.Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $serveSvcName }}
+                port:
+                  number: {{ $root.Values.serveFleet.service.port }}
+          {{- else if $host.paths }}
           {{- range $p := $host.paths }}
           - path: {{ $p.path | default $.Values.ingress.path | quote }}
             pathType: {{ $p.pathType | default $.Values.ingress.pathType }}

--- a/charts/oxy-app/values.yaml
+++ b/charts/oxy-app/values.yaml
@@ -568,11 +568,21 @@ pdb:
 # Set `serveFleet.enabled: false` (default) to render no oxy-serve
 # resources and preserve existing single-StatefulSet behaviour.
 #
-# Ingress routing: when `serveFleet.enabled: true` AND `ingress.enabled:
-# true`, the chart renders a SECOND Ingress entry that routes
-# `serveFleet.ingressPaths` to the oxy-serve Service. The default paths
-# list keeps IDE / files / git / compile on the StatefulSet and routes
-# everything else to oxy-serve.
+# Ingress routing:
+#   - Legacy (additive) mode: `ideRoutes` empty → catch-all `/` stays on
+#     the StatefulSet and `serveFleet.ingressPaths` peel off to oxy-serve.
+#     Used during the initial HA-split rollout; safest, smallest blast
+#     radius, but blocked from reaching the workspace-scoped tree
+#     because `/api/{workspace_id}/...` can't be peeled by prefix match.
+#   - Inverse mode: `ideRoutes` non-empty → catch-all `/` flips to
+#     oxy-serve, and only the IdeOnly patterns in `ideRoutes` peel off
+#     to the StatefulSet. This is the path to reach the original goal of
+#     "only filesystem-touching surfaces live on oxy-ide". Patterns use
+#     `pathType: ImplementationSpecific` so mid-segment wildcards like
+#     `/api/*/files` work natively on AWS ALB. See `ideRoutes` below.
+# The app-layer `OXY_ROLE` guardrail (returns 421 + `X-Oxy-Required-Role`
+# when a request lands on the wrong fleet) is the actual safety net;
+# ingress routing is an optimization on top.
 #
 # ── REQUIRED config for the compile boundary ───────────────────────────
 # The stateless fleet can ONLY serve a workspace that has been compiled (it
@@ -582,6 +592,57 @@ pdb:
 # working copy; per-worker clone-on-demand is a later phase). For S3 offload +
 # DuckDB-on-fleet, set `compileBoundary.blobS3Bucket`. After deploy, compile
 # existing workspaces once via the admin "Compile all uncompiled" backfill.
+# ── IdeOnly route override (inverse routing) ─────────────────────────────
+# When `serveFleet.enabled: true` AND this list is non-empty, the
+# Ingress flips: catch-all `/` → oxy-serve, and ONLY the patterns below
+# peel off to the singleton StatefulSet (oxy-ide). The default list
+# mirrors the `IdeOnly` entries in `crates/app/src/server/role_manifest.rs`
+# — surfaces that touch the workspace filesystem or `.git`. Operators
+# normally do NOT need to set this from the workload values file; bump
+# the chart `appVersion` when the role manifest changes upstream.
+#
+# Each entry: `{path, pathType?}`. `pathType` defaults to
+# `ImplementationSpecific` so mid-segment wildcards work on AWS ALB;
+# override with `Prefix` for left-anchored paths if you prefer.
+#
+# Set `ideRoutes: []` from the workload values to fall back to legacy
+# additive routing (catch-all → StatefulSet; `serveFleet.ingressPaths`
+# peeled to serve fleet).
+#
+# Caveats — both benign in practice because the app-layer `OXY_ROLE`
+# guardrail catches misroutes with a 421:
+#   - ALB wildcards are greedy across slashes, so `/api/?/files` (with
+#     the asterisk pattern) also matches `/api/a/b/files`. No such
+#     paths exist today.
+#   - A handful of GETs under an IdeOnly subtree (e.g.
+#     `GET /api/{ws}/compile/status`) are FleetOk in the manifest but
+#     land on `ide` here. Harmless — `ide` accepts FleetOk.
+ideRoutes:
+  # Pages — full IDE SPA.
+  - path: /ide
+  - path: /ide/*
+  # Workspace-scoped file tree + per-file CRUD.
+  - path: /api/*/files
+  - path: /api/*/files/*
+  # Compile dispatcher (POST). The status GET is FleetOk in the
+  # manifest but lands on ide here; harmless.
+  - path: /api/*/compile
+  - path: /api/*/compile/*
+  # Working-copy git operations.
+  - path: /api/*/git
+  - path: /api/*/git/*
+  # Workspace onboarding subtree (clones + scaffolds).
+  - path: /api/*/onboarding
+  - path: /api/*/onboarding/*
+  # Modeling / Airform dbt projects live on disk.
+  - path: /api/*/modeling/*
+  # Branch switch — moves HEAD on the working copy.
+  - path: /api/*/switch-branch
+  # Org-scoped workspace creation (clones the repo into a new workspace).
+  - path: /api/orgs/*/onboarding/demo
+  - path: /api/orgs/*/onboarding/new
+  - path: /api/orgs/*/onboarding/github
+
 serveFleet:
   enabled: false
   # Number of stateless pods. HPA-friendly — these have no PVC, no in-


### PR DESCRIPTION
## Summary

Today's HA-split chart can only peel left-anchored prefixes off to the serve fleet. That blocks the original goal — *"only filesystem-touching surfaces should live on oxy-ide"* — because the entire `/api/{workspace_id}/*` tree (most of the API) sits behind a mid-path UUID that no prefix can isolate.

This PR flips the default. When `serveFleet.enabled: true`:

- Catch-all `/` → **serve fleet**.
- A new `ideRoutes` list → **StatefulSet** (oxy-ide), with `pathType: ImplementationSpecific` so mid-segment wildcards like `/api/*/files` reach the AWS ALB Controller as native ALB path patterns.
- The default `ideRoutes` ships **pre-populated in the chart** with the 15 patterns from [`crates/app/src/server/role_manifest.rs`](https://github.com/oxy-hq/oxygen-internal/blob/main/crates/app/src/server/role_manifest.rs) — so the workload values file does NOT have to track the list. Bump `appVersion` here when that file changes upstream.

The app-layer `OXY_ROLE` guardrail (returns 421 + `X-Oxy-Required-Role` when a request lands on the wrong fleet) is the real safety net; the ingress routing is an optimization on top of it. ALB's `*` is greedy across slashes, so `/api/*/files` also matches `/api/a/b/files` — fine because the guardrail catches it explicitly rather than silently serving from the wrong fleet.

## Compatibility

| `serveFleet.enabled` | `ideRoutes` | Behavior |
|---|---|---|
| `false` (default) | (ignored) | Single-pod StatefulSet — byte-identical to today |
| `true` | chart default (15 patterns) | **New default**: catch-all → serve, IdeOnly → ide |
| `true` | `[]` from workload | Legacy mode: catch-all → ide, `serveFleet.ingressPaths` peeled to serve |

Existing legacy deployments stay unchanged unless they opt into inverse mode by upgrading and accepting the new chart default.

## Smoke test (via `helm template`)

```text
inverse:  16 rules  (15 IdeOnly → ide, 1 catch-all → serve)
legacy:    3 rules  (2 ingressPaths → serve, 1 catch-all → ide)
disabled:  1 rule   (catch-all → ide)
```

## Test plan

- [ ] Roll out the new chart to `oxy-dev` with a values change in [oxy-workload `oxy-dev.yaml`](https://github.com/oxy-hq/infrastructure-oxy-workload) (separate PR — drops `serveFleet.ingressPaths`, lets the chart default for `ideRoutes` apply).
- [ ] Verify `X-Oxy-Served-By` for representative endpoints:
  ```bash
  for p in '/api/orgs/X/workspaces' '/api/Y/threads' '/api/Y/files' '/api/Y/git/status' '/api/Y/compile' '/ide'; do
    curl -sI -H "authorization: $JWT" "https://app-dev.oxygen-hq.com$p" | grep -i x-oxy-served-by
  done
  ```
  Expected: first two `serve@...`, last four `ide@...`.
- [ ] Watch serve-fleet logs for any `421 ... X-Oxy-Required-Role: ide` — any hit there means the role manifest is missing an entry that should be added to `IDE_ONLY_PATTERNS` (preferred fix; the ingress list should mirror the manifest, not diverge from it).