### PR TITLE
test(oxy-app): parallelize integration suite with shared postgres

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -60,6 +60,14 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
+          # The integration harness lives in scripts/, not the chart. A
+          # scripts-only change leaves `ct list-changed` empty and would
+          # silently SKIP the kind cluster + integration tests — so the
+          # green check would not actually exercise the harness change.
+          # Treat any scripts/ change as "changed" too.
+          if ! git diff --quiet "origin/${{ github.event.repository.default_branch }}...HEAD" -- scripts/; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Make scripts executable
         run: |

--- a/charts/oxy-app/Chart.yaml
+++ b/charts/oxy-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oxy-app
 description: A Helm chart for Oxy application deployment on kubernetes
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: "0.5.49"
 keywords:
   - oxy

--- a/charts/oxy-app/templates/ingress.yaml
+++ b/charts/oxy-app/templates/ingress.yaml
@@ -5,6 +5,17 @@
 {{- $root := . -}}
 {{- $serveEnabled := .Values.serveFleet.enabled -}}
 {{- $servePaths := default (list) .Values.serveFleet.ingressPaths -}}
+{{- $ideRoutes := default (list) .Values.ideRoutes -}}
+{{- /*
+  Inverse routing kicks in when serveFleet.enabled is true AND
+  ideRoutes is non-empty: the catch-all flips to the serve fleet, and
+  only the listed IdeOnly patterns peel off to the singleton StatefulSet
+  (oxy-ide). Otherwise the chart stays in the legacy additive shape
+  (catch-all → StatefulSet, serveFleet.ingressPaths peeled to serve).
+  Default ideRoutes ships pre-populated in values.yaml so the workload
+  does not need to track the role-manifest list.
+*/}}
+{{- $inverseMode := and $serveEnabled (gt (len $ideRoutes) 0) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -29,15 +40,37 @@ spec:
       http:
         paths:
           {{- /*
-            HA split routing. When `serveFleet.enabled: true`, the chart
-            renders one Ingress rule per path in `serveFleet.ingressPaths`
-            FIRST (more specific), pointing them at the stateless
-            oxy-serve Service. The catch-all path below then routes
-            everything else to the singleton StatefulSet (oxy-ide). Path
-            matching is order-dependent in most ingress controllers; we
-            list the specific paths before the catch-all explicitly.
+            (1) IdeOnly patterns. Most specific, listed first. Only
+            rendered in inverse mode — when the serve fleet is off,
+            everything already lands on the StatefulSet via the
+            catch-all, so emitting these entries would create 15
+            redundant ALB rules.
+            Default pathType ImplementationSpecific is what the AWS ALB
+            Ingress Controller passes through unmodified, so mid-segment
+            wildcards (the asterisk in /api/WORKSPACE/files) reach the
+            ALB as a native path pattern. Override per-entry with
+            pathType Prefix for left-anchored paths.
           */}}
-          {{- if $serveEnabled }}
+          {{- if $inverseMode }}
+          {{- range $r := $ideRoutes }}
+          - path: {{ $r.path | quote }}
+            pathType: {{ default "ImplementationSpecific" $r.pathType }}
+            backend:
+              service:
+                name: {{ $svcName }}
+                port:
+                  number: {{ $root.Values.service.port }}
+          {{- end }}
+          {{- end }}
+          {{- /*
+            (2) Legacy additive list (serveFleet.ingressPaths). Only
+            useful in legacy mode where the catch-all goes to the
+            StatefulSet — these prefixes peel specific paths to the
+            serve fleet. In inverse mode the catch-all already lands
+            on the serve fleet, so re-emitting these would create
+            duplicate ALB rules; skip them.
+          */}}
+          {{- if and $serveEnabled (not $inverseMode) }}
           {{- range $servePaths }}
           - path: {{ . | quote }}
             pathType: Prefix
@@ -48,7 +81,21 @@ spec:
                   number: {{ $root.Values.serveFleet.service.port }}
           {{- end }}
           {{- end }}
-          {{- if $host.paths }}
+          {{- /*
+            (3) Catch-all. Inverse mode points it at the serve fleet;
+            otherwise it stays on the StatefulSet (legacy behavior,
+            preserved when ideRoutes is empty so existing deployments
+            upgrade byte-identical).
+          */}}
+          {{- if $inverseMode }}
+          - path: {{ $.Values.ingress.path | quote }}
+            pathType: {{ $.Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $serveSvcName }}
+                port:
+                  number: {{ $root.Values.serveFleet.service.port }}
+          {{- else if $host.paths }}
           {{- range $p := $host.paths }}
           - path: {{ $p.path | default $.Values.ingress.path | quote }}
             pathType: {{ $p.pathType | default $.Values.ingress.pathType }}

--- a/charts/oxy-app/values.yaml
+++ b/charts/oxy-app/values.yaml
@@ -568,11 +568,21 @@ pdb:
 # Set `serveFleet.enabled: false` (default) to render no oxy-serve
 # resources and preserve existing single-StatefulSet behaviour.
 #
-# Ingress routing: when `serveFleet.enabled: true` AND `ingress.enabled:
-# true`, the chart renders a SECOND Ingress entry that routes
-# `serveFleet.ingressPaths` to the oxy-serve Service. The default paths
-# list keeps IDE / files / git / compile on the StatefulSet and routes
-# everything else to oxy-serve.
+# Ingress routing:
+#   - Legacy (additive) mode: `ideRoutes` empty → catch-all `/` stays on
+#     the StatefulSet and `serveFleet.ingressPaths` peel off to oxy-serve.
+#     Used during the initial HA-split rollout; safest, smallest blast
+#     radius, but blocked from reaching the workspace-scoped tree
+#     because `/api/{workspace_id}/...` can't be peeled by prefix match.
+#   - Inverse mode: `ideRoutes` non-empty → catch-all `/` flips to
+#     oxy-serve, and only the IdeOnly patterns in `ideRoutes` peel off
+#     to the StatefulSet. This is the path to reach the original goal of
+#     "only filesystem-touching surfaces live on oxy-ide". Patterns use
+#     `pathType: ImplementationSpecific` so mid-segment wildcards like
+#     `/api/*/files` work natively on AWS ALB. See `ideRoutes` below.
+# The app-layer `OXY_ROLE` guardrail (returns 421 + `X-Oxy-Required-Role`
+# when a request lands on the wrong fleet) is the actual safety net;
+# ingress routing is an optimization on top.
 #
 # ── REQUIRED config for the compile boundary ───────────────────────────
 # The stateless fleet can ONLY serve a workspace that has been compiled (it
@@ -582,6 +592,57 @@ pdb:
 # working copy; per-worker clone-on-demand is a later phase). For S3 offload +
 # DuckDB-on-fleet, set `compileBoundary.blobS3Bucket`. After deploy, compile
 # existing workspaces once via the admin "Compile all uncompiled" backfill.
+# ── IdeOnly route override (inverse routing) ─────────────────────────────
+# When `serveFleet.enabled: true` AND this list is non-empty, the
+# Ingress flips: catch-all `/` → oxy-serve, and ONLY the patterns below
+# peel off to the singleton StatefulSet (oxy-ide). The default list
+# mirrors the `IdeOnly` entries in `crates/app/src/server/role_manifest.rs`
+# — surfaces that touch the workspace filesystem or `.git`. Operators
+# normally do NOT need to set this from the workload values file; bump
+# the chart `appVersion` when the role manifest changes upstream.
+#
+# Each entry: `{path, pathType?}`. `pathType` defaults to
+# `ImplementationSpecific` so mid-segment wildcards work on AWS ALB;
+# override with `Prefix` for left-anchored paths if you prefer.
+#
+# Set `ideRoutes: []` from the workload values to fall back to legacy
+# additive routing (catch-all → StatefulSet; `serveFleet.ingressPaths`
+# peeled to serve fleet).
+#
+# Caveats — both benign in practice because the app-layer `OXY_ROLE`
+# guardrail catches misroutes with a 421:
+#   - ALB wildcards are greedy across slashes, so `/api/?/files` (with
+#     the asterisk pattern) also matches `/api/a/b/files`. No such
+#     paths exist today.
+#   - A handful of GETs under an IdeOnly subtree (e.g.
+#     `GET /api/{ws}/compile/status`) are FleetOk in the manifest but
+#     land on `ide` here. Harmless — `ide` accepts FleetOk.
+ideRoutes:
+  # Pages — full IDE SPA.
+  - path: /ide
+  - path: /ide/*
+  # Workspace-scoped file tree + per-file CRUD.
+  - path: /api/*/files
+  - path: /api/*/files/*
+  # Compile dispatcher (POST). The status GET is FleetOk in the
+  # manifest but lands on ide here; harmless.
+  - path: /api/*/compile
+  - path: /api/*/compile/*
+  # Working-copy git operations.
+  - path: /api/*/git
+  - path: /api/*/git/*
+  # Workspace onboarding subtree (clones + scaffolds).
+  - path: /api/*/onboarding
+  - path: /api/*/onboarding/*
+  # Modeling / Airform dbt projects live on disk.
+  - path: /api/*/modeling/*
+  # Branch switch — moves HEAD on the working copy.
+  - path: /api/*/switch-branch
+  # Org-scoped workspace creation (clones the repo into a new workspace).
+  - path: /api/orgs/*/onboarding/demo
+  - path: /api/orgs/*/onboarding/new
+  - path: /api/orgs/*/onboarding/github
+
 serveFleet:
   enabled: false
   # Number of stateless pods. HPA-friendly — these have no PVC, no in-

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,81 +2,81 @@
 set -e
 
 # Integration Test Script for Oxy-App Helm Chart
-# Runs comprehensive integration tests against a Kubernetes cluster
+#
+# Runs the chart against a real Kubernetes cluster (kind in CI). Rewritten
+# for speed: the suite used to run six releases SERIALLY in one namespace,
+# each spinning up its OWN postgres StatefulSet + PVC, then tearing it down
+# with `helm uninstall --wait`. On a flaky-storage runner every test ate a
+# ~5min teardown tail and the whole suite hit 36min.
+#
+# This version:
+#   - Starts ONE shared postgres (Deployment + Service, emptyDir, no PVC)
+#     and gives each test its OWN database on it — so tests never spin up
+#     their own postgres and never race on migrations.
+#   - Runs each test in its OWN namespace, in a bounded PARALLEL pool.
+#   - Never blocks on graceful teardown: the kind cluster is ephemeral, so
+#     cleanup just deletes namespaces with --wait=false.
+#   - Uses tight, explicit timeouts everywhere so storage flakiness fails
+#     fast instead of burning the 5min helm default.
 
 CHART_PATH="./charts/oxy-app"
-NAMESPACE="helm-integration-test"
+INFRA_NS="helm-it-infra"           # holds the shared postgres
+NS_PREFIX="helm-it"                # per-test namespaces: helm-it-<name>
 
-# List of test release names used by cleanup routines. Keep in sync with test_* functions.
-TEST_RELEASES=(
-    "test-default"
-    "test-ingress"
-    "test-postgres"
-    "test-production"
-    "test-persist"
-    "upgrade-test"
-    "resource-test"
-)
+# Shared postgres connection (one server, one DB per test).
+PG_RELEASE_SVC="shared-postgres"
+PG_USER="oxy"
+PG_PASSWORD="oxypass"
+PG_HOST="${PG_RELEASE_SVC}.${INFRA_NS}.svc.cluster.local"
+PG_PORT=5432
+
+# How many tests to run concurrently. Kept modest so a single kind node
+# (and its storage provisioner) is not overwhelmed by parallel PVC binds.
+MAX_PARALLEL="${MAX_PARALLEL:-3}"
+
+# Tests to run. Each name maps to: a test-values file, a per-test database,
+# and a test_<name> function. The dedicated "postgres" test was dropped —
+# every test now exercises postgres, so it was pure duplication.
+TESTS=(default ingress production persist upgrade)
+
+# Namespaces we create (infra + one per test) — for cleanup.
+ALL_NAMESPACES=("$INFRA_NS")
+for t in "${TESTS[@]}"; do ALL_NAMESPACES+=("${NS_PREFIX}-${t}"); done
 
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-log_info() {
-    echo -e "${GREEN}[INFO]${NC} $1"
-}
+log_info()    { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
+log_section() { echo -e "${BLUE}=== $1 ===${NC}"; }
 
-log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
-}
-
-log_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
-}
-
-log_section() {
-    echo -e "${BLUE}=== $1 ===${NC}"
-}
-
-# Dump every signal that diagnoses a failed helm install / pod-not-ready.
-# Without a release selector, dumps the entire test namespace — used
-# from the trap on script-exit so a 5m timeout on the StatefulSet no
-# longer prints just "InProgress, Ready: 0/1". kubectl describe +
-# events + pod logs land in the CI log alongside the error.
+# Dump every signal that diagnoses a failed helm install / pod-not-ready in
+# a namespace. Called by the parallel runner when a test subshell exits
+# non-zero, so the CI log shows describe + events + pod logs next to the
+# failure instead of a bare "context deadline exceeded".
 dump_failure_diagnostics() {
-    local selector_args=()
-    if [[ -n "${1:-}" ]]; then
-        selector_args=(-l "app.kubernetes.io/instance=$1")
-        log_warn "Dumping cluster diagnostics for release '$1'..."
-    else
-        log_warn "Dumping cluster diagnostics for namespace '$NAMESPACE'..."
-    fi
+    local ns="$1"
+    log_warn "Dumping cluster diagnostics for namespace '$ns'..."
     echo "--- pods ---"
-    kubectl get pods -n "$NAMESPACE" "${selector_args[@]}" -o wide || true
+    kubectl get pods -n "$ns" -o wide || true
     echo "--- pvcs ---"
-    kubectl get pvc -n "$NAMESPACE" || true
+    kubectl get pvc -n "$ns" || true
     echo "--- events (last 30, by lastTimestamp) ---"
-    kubectl get events -n "$NAMESPACE" --sort-by=.lastTimestamp 2>/dev/null | tail -30 || true
+    kubectl get events -n "$ns" --sort-by=.lastTimestamp 2>/dev/null | tail -30 || true
     echo "--- describe pods ---"
-    kubectl describe pods -n "$NAMESPACE" "${selector_args[@]}" 2>/dev/null \
-        | sed -n '1,300p' || true
+    kubectl describe pods -n "$ns" 2>/dev/null | sed -n '1,300p' || true
     echo "--- logs (current container) ---"
-    kubectl logs -n "$NAMESPACE" "${selector_args[@]}" \
-        --all-containers=true --tail=200 --prefix=true 2>/dev/null || true
+    kubectl logs -n "$ns" --all-containers=true --tail=200 --prefix=true \
+        -l app.kubernetes.io/name=oxy-app 2>/dev/null || true
     echo "--- logs (previous container, if any) ---"
-    kubectl logs -n "$NAMESPACE" "${selector_args[@]}" \
-        --all-containers=true --tail=200 --previous --prefix=true 2>/dev/null || true
+    kubectl logs -n "$ns" --all-containers=true --tail=200 --previous --prefix=true \
+        -l app.kubernetes.io/name=oxy-app 2>/dev/null || true
 }
-
-# Install the failure-diagnostic dump as an ERR trap so EVERY helm
-# install / kubectl wait failure produces describe + logs alongside
-# the cryptic "context deadline exceeded" message. Without this the
-# integration suite was silently broken for a month before anyone
-# could see why.
-trap 'rc=$?; if [[ $rc -ne 0 && -n "${NAMESPACE:-}" ]]; then dump_failure_diagnostics; fi; exit $rc' ERR
 
 show_usage() {
     cat <<EOF
@@ -85,693 +85,325 @@ Usage: $0 [OPTIONS]
 Integration test runner for oxy-app Helm chart
 
 OPTIONS:
-    --verbose           Enable verbose output
-    --cleanup           Clean up test resources after completion
-
-EXAMPLES:
-    $0                  # Run integration tests
-    $0 --cleanup        # Run integration tests and cleanup afterwards
-    $0 --verbose        # Run with verbose output
+    --verbose           Enable verbose output (set -x)
+    --cleanup           Delete test namespaces after completion
+    -h, --help          Show this help
 
 ENVIRONMENT VARIABLES:
-    CI                  Set to 'true' to skip local cluster setup
-    NAMESPACE           Test namespace (default: helm-integration-test)
-
+    NAMESPACE           Ignored (kept for back-compat; namespaces are derived)
+    MAX_PARALLEL        Max concurrent tests (default: 3)
 EOF
-}
-
-cleanup() {
-    log_info "Cleaning up test resources..."
-
-    # List of test releases to clean up (maintained in TEST_RELEASES)
-    for release in "${TEST_RELEASES[@]}"; do
-        if helm list -q -n "$NAMESPACE" 2>/dev/null | grep -q "^${release}$"; then
-            log_info "Uninstalling release: $release"
-            helm uninstall "$release" -n "$NAMESPACE" --wait --timeout=300s || true
-        fi
-    done
-
-    # Aggressive PVC cleanup - delete any PVCs that might be stuck
-    log_info "Cleaning up any remaining PVCs..."
-    kubectl get pvc -n "$NAMESPACE" -o name 2>/dev/null | while read pvc; do
-        if [ -n "$pvc" ]; then
-            log_info "Force deleting PVC: $pvc"
-            kubectl delete "$pvc" -n "$NAMESPACE" --force --grace-period=0 || true
-        fi
-    done
-
-    # Clean up any stuck pods that might be holding PVCs
-    log_info "Cleaning up any stuck pods..."
-    kubectl get pods -n "$NAMESPACE" -o name 2>/dev/null | while read pod; do
-        if [ -n "$pod" ]; then
-            log_info "Force deleting pod: $pod"
-            kubectl delete "$pod" -n "$NAMESPACE" --force --grace-period=0 || true
-        fi
-    done
-
-    # Delete namespace if it exists (this should clean up everything)
-    if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
-        log_info "Deleting namespace: $NAMESPACE"
-        kubectl delete namespace "$NAMESPACE" --wait=true --timeout=60s || true
-    fi
-
-    # Wait a moment for cleanup to complete
-    sleep 2
-}
-
-aggressive_pre_cleanup() {
-    log_info "Performing aggressive pre-test cleanup..."
-
-    # If namespace exists, check for any existing resources
-    if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
-        log_info "Found existing test namespace, cleaning up..."
-
-        # List what we're about to clean
-        log_info "Existing resources in namespace:"
-        kubectl get all,pvc,secrets,configmaps -n "$NAMESPACE" || true
-
-        # Force cleanup everything
-        cleanup
-
-        # Recreate clean namespace
-        log_info "Recreating clean namespace..."
-        kubectl delete namespace "$NAMESPACE" --ignore-not-found=true --wait=true --timeout=60s || true
-        sleep 3
-    fi
 }
 
 check_prerequisites() {
     log_info "Checking prerequisites..."
-
-    local missing_tools=()
-
-    # Check if helm is installed
-    if ! command -v helm &> /dev/null; then
-        missing_tools+=("helm")
-    fi
-
-    # Check if kubectl is installed (required for integration tests)
-    if ! command -v kubectl &> /dev/null; then
-        missing_tools+=("kubectl")
-    fi
-
-    if [[ ${#missing_tools[@]} -gt 0 ]]; then
-        log_error "Missing required tools: ${missing_tools[*]}"
-        log_info "Please install the missing tools and try again"
+    local missing=()
+    command -v helm    &>/dev/null || missing+=("helm")
+    command -v kubectl &>/dev/null || missing+=("kubectl")
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log_error "Missing required tools: ${missing[*]}"
         exit 1
     fi
-
+    if ! kubectl cluster-info &>/dev/null; then
+        log_error "No Kubernetes cluster available."
+        exit 1
+    fi
     log_info "Prerequisites check passed!"
 }
 
-debug_kind_storage() {
-    log_info "Debugging Kind cluster storage configuration..."
-
-    # Check if this is a Kind cluster
-    cluster_name=$(kubectl config current-context 2>/dev/null || echo "unknown")
-    if [[ "$cluster_name" == *"kind"* ]]; then
-        log_info "Detected Kind cluster: $cluster_name"
-
-        # Check available storage classes
-        log_info "Available StorageClasses:"
-        kubectl get storageclass -o wide || true
-
-        # Check if standard StorageClass exists (Kind default)
-        if kubectl get storageclass standard >/dev/null 2>&1; then
-            log_info "Standard StorageClass found:"
-            kubectl describe storageclass standard || true
-        else
-            log_warn "Standard StorageClass not found"
-        fi
-
-        # Check for default StorageClass
-        default_sc=$(kubectl get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
-        if [ -n "$default_sc" ]; then
-            log_info "Default StorageClass: $default_sc"
-        else
-            log_warn "No default StorageClass configured"
-
-            # Try to set standard as default if it exists
-            if kubectl get storageclass standard >/dev/null 2>&1; then
-                log_info "Setting 'standard' StorageClass as default for Kind cluster"
-                kubectl patch storageclass standard -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}' || log_warn "Failed to set default StorageClass"
-            fi
-        fi
-
-        # Check Kind node storage capacity
-        log_info "Node storage information:"
-        kubectl get nodes -o custom-columns=NAME:.metadata.name,CAPACITY:.status.capacity.storage,ALLOCATABLE:.status.allocatable.storage || true
-
-        # Check if local-path-storage is running (Kind's default provisioner)
-        log_info "Checking local-path-storage components:"
-        kubectl get pods -n local-path-storage 2>/dev/null || log_warn "local-path-storage namespace not found"
-        kubectl get pods -A | grep -E "(local-path|storage)" || log_warn "No storage-related pods found"
-
-    else
-        log_info "Not a Kind cluster (context: $cluster_name), skipping Kind-specific storage checks"
-    fi
+# Per-test helm install flags that point the app at its dedicated database
+# on the shared postgres and disable the bundled postgres subchart (which
+# also strips the wait-for-postgres init container, since the server is
+# already up before any test starts).
+shared_db_args() {
+    local db="$1"
+    local url="postgresql://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${db}"
+    echo "--set database.postgres.enabled=false --set-string env.OXY_DATABASE_URL=${url}"
 }
 
-setup_test_environment() {
-    log_info "Setting up test environment..."
+setup_shared_infra() {
+    log_section "Setting up shared infrastructure"
 
-    # Aggressive cleanup of any existing resources first
-    aggressive_pre_cleanup
-
-    # Create fresh namespace
-    kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
-
-    # Debug storage configuration
-    debug_kind_storage
-
-    # Add required Helm repositories for dependencies
-    log_info "Adding Helm repositories..."
-    # Add groundhog2k repo for postgres subchart
+    # Build chart dependencies from Chart.lock (subcharts are condition-gated
+    # off at install time, but the packaged .tgz must exist to template).
+    log_info "Adding Helm repositories + building dependencies..."
     helm repo add groundhog2k https://groundhog2k.github.io/helm-charts/ 2>/dev/null || true
-    helm repo update
+    helm repo update >/dev/null
+    helm dependency build "$CHART_PATH" >/dev/null
 
-    # Build helm dependencies using Chart.lock (not update)
-    # This ensures we use the exact versions locked in Chart.lock
-    log_info "Building Helm dependencies from Chart.lock..."
-    helm dependency build "$CHART_PATH"
+    log_info "Creating namespaces..."
+    for ns in "${ALL_NAMESPACES[@]}"; do
+        kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+    done
 
-    log_info "Test environment setup complete!"
-}
-
-
-test_simple_pvc() {
-    log_info "Testing simple PVC creation before StatefulSet..."
-
-    # Create a simple test PVC to verify storage provisioning works
-    cat <<EOF | kubectl apply -n "$NAMESPACE" -f -
-apiVersion: v1
-kind: PersistentVolumeClaim
+    log_info "Deploying shared postgres (emptyDir, no PVC)..."
+    kubectl apply -n "$INFRA_NS" -f - >/dev/null <<EOF
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: test-pvc-simple
-  namespace: $NAMESPACE
+  name: $PG_RELEASE_SVC
+  labels: { app: shared-postgres }
 spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 100Mi
+  replicas: 1
+  selector: { matchLabels: { app: shared-postgres } }
+  template:
+    metadata:
+      labels: { app: shared-postgres }
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          env:
+            - { name: POSTGRES_USER, value: "$PG_USER" }
+            - { name: POSTGRES_PASSWORD, value: "$PG_PASSWORD" }
+            - { name: POSTGRES_DB, value: "postgres" }
+            - { name: PGDATA, value: "/var/lib/postgresql/data/pgdata" }
+          ports: [{ containerPort: 5432 }]
+          readinessProbe:
+            exec: { command: ["pg_isready", "-U", "$PG_USER"] }
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits:   { cpu: 500m, memory: 512Mi }
+          volumeMounts:
+            - { name: data, mountPath: /var/lib/postgresql/data }
+      volumes:
+        - { name: data, emptyDir: {} }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: $PG_RELEASE_SVC
+spec:
+  selector: { app: shared-postgres }
+  ports: [{ port: 5432, targetPort: 5432 }]
 EOF
 
-    # Wait for PVC to be bound
-    log_info "Waiting for test PVC to be bound..."
-    if kubectl wait --for=condition=bound pvc test-pvc-simple -n "$NAMESPACE" --timeout=60s; then
-        log_info "Simple PVC test passed - storage provisioning works"
-        kubectl describe pvc test-pvc-simple -n "$NAMESPACE" || true
-    else
-        log_error "Simple PVC test failed - storage provisioning issues detected"
-        kubectl describe pvc test-pvc-simple -n "$NAMESPACE" || true
-        kubectl get events -n "$NAMESPACE" --field-selector involvedObject.name=test-pvc-simple || true
-    fi
+    log_info "Waiting for shared postgres to be ready..."
+    kubectl rollout status deploy/"$PG_RELEASE_SVC" -n "$INFRA_NS" --timeout=120s
 
-    # Cleanup test PVC
-    kubectl delete pvc test-pvc-simple -n "$NAMESPACE" || true
+    # One empty database per test — isolates migrations so parallel tests
+    # never collide on a shared schema.
+    log_info "Creating per-test databases..."
+    local pg_pod
+    pg_pod=$(kubectl get pod -n "$INFRA_NS" -l app=shared-postgres -o jsonpath='{.items[0].metadata.name}')
+    for t in "${TESTS[@]}"; do
+        kubectl exec -n "$INFRA_NS" "$pg_pod" -- \
+            psql -U "$PG_USER" -d postgres -c "CREATE DATABASE db_${t} OWNER ${PG_USER};" >/dev/null 2>&1 || true
+    done
+
+    log_info "Shared infrastructure ready!"
 }
 
-test_default_deployment() {
-    log_info "Testing default deployment..."
-    local test_start=$SECONDS
+# ── Individual tests ─────────────────────────────────────────────────────
+# Each runs in its own namespace ${NS_PREFIX}-<name> against database db_<name>.
+# No per-test teardown: namespaces are dropped wholesale at the end.
 
+test_default() {
+    local ns="${NS_PREFIX}-default"
+    log_info "[default] installing..."
+    # shellcheck disable=SC2046
     helm install test-default "$CHART_PATH" \
         -f "$CHART_PATH/test-values/default-values.yaml" \
-        -n "$NAMESPACE" \
-        --wait --timeout=5m
+        $(shared_db_args db_default) \
+        -n "$ns" --wait --timeout=120s
 
-    # Wait for pods to be ready
-    kubectl wait --for=condition=ready pod \
-        -l app.kubernetes.io/instance=test-default \
-        -n "$NAMESPACE" \
-        --timeout=90s
-
-    # Test service connectivity
-    log_info "Testing service connectivity..."
-    kubectl port-forward service/oxy-test-default 8080:80 -n "$NAMESPACE" &
-    PORT_FORWARD_PID=$!
-
-    # Wait for port-forward to be ready (max 15s)
-    for i in {1..30}; do
-        if curl -fs http://localhost:8080/ >/dev/null 2>&1; then
-            break
-        fi
+    log_info "[default] checking service connectivity..."
+    kubectl port-forward service/oxy-test-default 18080:80 -n "$ns" >/dev/null 2>&1 &
+    local pf=$!
+    local ok=1
+    for _ in {1..30}; do
+        if curl -fs http://localhost:18080/ >/dev/null 2>&1; then ok=0; break; fi
         sleep 0.5
     done
-    if curl -f http://localhost:8080/ >/dev/null 2>&1; then
-        log_info "Default deployment health check passed!"
-    else
-        log_error "Default deployment health check failed!"
-        kill $PORT_FORWARD_PID || true
-        return 1
-    fi
-
-    kill $PORT_FORWARD_PID || true
-
-    # Cleanup this test
-    helm uninstall test-default -n "$NAMESPACE" --wait
-
-    local test_duration=$((SECONDS - test_start))
-    log_info "Default deployment test passed in ${test_duration}s!"
+    kill $pf 2>/dev/null || true
+    [[ $ok -eq 0 ]] || { log_error "[default] health check failed"; return 1; }
+    log_info "[default] passed!"
 }
 
-test_ingress_deployment() {
-    log_info "Testing deployment with ingress..."
-
+test_ingress() {
+    local ns="${NS_PREFIX}-ingress"
+    log_info "[ingress] installing..."
+    # shellcheck disable=SC2046
     helm install test-ingress "$CHART_PATH" \
         -f "$CHART_PATH/test-values/with-ingress-values.yaml" \
-        -n "$NAMESPACE" \
-        --wait --timeout=5m
+        $(shared_db_args db_ingress) \
+        -n "$ns" --wait --timeout=120s
 
-    # Wait for pods to be ready
-    kubectl wait --for=condition=ready pod \
-        -l app.kubernetes.io/instance=test-ingress \
-        -n "$NAMESPACE" \
-        --timeout=90s
-
-    # Verify ingress is created
-    if kubectl get ingress oxy-test-ingress -n "$NAMESPACE" -o jsonpath='{.spec.rules[0].host}' | grep -q "test-oxy-app.local"; then
-        log_info "Ingress configuration verified!"
+    if kubectl get ingress oxy-test-ingress -n "$ns" -o jsonpath='{.spec.rules[0].host}' | grep -q "test-oxy-app.local"; then
+        log_info "[ingress] passed!"
     else
-        log_error "Ingress configuration failed!"
-        return 1
+        log_error "[ingress] ingress host not as expected"; return 1
     fi
-
-    # Cleanup this test
-    helm uninstall test-ingress -n "$NAMESPACE" --wait
-
-    log_info "Ingress deployment test passed!"
 }
 
-test_postgres_deployment() {
-    log_info "Testing deployment with PostgreSQL..."
-
-    # Debug: Show what we're about to install
-    log_info "Chart dependencies:"
-    helm dependency list "$CHART_PATH" || true
-
-    # Install with longer timeout for PostgreSQL startup
-    log_info "Installing with PostgreSQL enabled..."
-    if ! helm install test-postgres "$CHART_PATH" \
-        -f "$CHART_PATH/test-values/with-postgres-values.yaml" \
-        -n "$NAMESPACE" \
-        --wait --timeout=5m; then
-        log_error "Helm install failed"
-        log_info "Getting pod status:"
-        kubectl get pods -n "$NAMESPACE" -o wide || true
-        log_info "Getting services:"
-        kubectl get svc -n "$NAMESPACE" -o wide || true
-        log_info "Describing PostgreSQL pod:"
-        kubectl describe pod -l app.kubernetes.io/name=postgres -n "$NAMESPACE" || true
-        log_info "PostgreSQL pod logs:"
-        kubectl logs -l app.kubernetes.io/name=postgres -n "$NAMESPACE" --tail=100 || true
-        log_info "Describing app pod:"
-        kubectl describe pod -l app.kubernetes.io/instance=test-postgres -n "$NAMESPACE" || true
-        log_info "Init container logs (wait-for-postgres):"
-        kubectl logs -l app.kubernetes.io/instance=test-postgres -n "$NAMESPACE" -c wait-for-postgres --tail=50 || true
-        log_info "App pod logs:"
-        kubectl logs -l app.kubernetes.io/instance=test-postgres -n "$NAMESPACE" --tail=100 || true
-        return 1
-    fi
-
-    # Wait for app pod to be ready
-    log_info "Waiting for application pod to be ready..."
-    if ! kubectl wait --for=condition=ready pod \
-        -l app.kubernetes.io/instance=test-postgres \
-        -n "$NAMESPACE" \
-        --timeout=240s; then
-        log_error "Application pod failed to become ready"
-        kubectl get pods -n "$NAMESPACE" -o wide || true
-        kubectl describe pod -l app.kubernetes.io/instance=test-postgres -n "$NAMESPACE" || true
-        kubectl logs -l app.kubernetes.io/instance=test-postgres -n "$NAMESPACE" --tail=50 || true
-        return 1
-    fi
-
-    # Test database connectivity
-    log_info "Testing database connectivity..."
-    postgres_pod=$(kubectl get pod -l app.kubernetes.io/name=postgres -n "$NAMESPACE" -o jsonpath='{.items[0].metadata.name}')
-    if [ -n "$postgres_pod" ]; then
-        if kubectl exec -n "$NAMESPACE" "$postgres_pod" -- pg_isready -U app -d app >/dev/null 2>&1; then
-            log_info "PostgreSQL connectivity test passed!"
-        else
-            log_error "PostgreSQL connectivity test failed!"
-            return 1
-        fi
-    else
-        log_warn "Could not find PostgreSQL pod, skipping connectivity test"
-    fi
-
-    # Cleanup this test
-    helm uninstall test-postgres -n "$NAMESPACE" --wait --timeout=5m
-
-    log_info "PostgreSQL deployment test passed!"
-}
-
-test_persistence_deployment() {
-    log_info "Testing deployment with persistence..."
-
-    # Run simple PVC test first
-    test_simple_pvc
-
-    # Debug: Check available StorageClasses before installation
-    log_info "Available StorageClasses in cluster:"
-    kubectl get storageclass -o wide || true
-
-    # Debug: Check if default StorageClass exists
-    default_sc=$(kubectl get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
-    if [ -n "$default_sc" ]; then
-        log_info "Default StorageClass found: $default_sc"
-    else
-        log_warn "No default StorageClass found"
-    fi
-
-    # Install with enhanced debugging
-    log_info "Installing Helm chart: test-persist with values: ./charts/oxy-app/test-values/with-persistence-values.yaml"
-    if helm install test-persist "$CHART_PATH" \
-        -f "$CHART_PATH/test-values/with-persistence-values.yaml" \
-        -n "$NAMESPACE" \
-        --wait --timeout=5m; then
-        log_info "Helm install succeeded"
-    else
-        log_error "Helm install failed"
-        # Debug: Show all resources created
-        kubectl get all -l app.kubernetes.io/instance=test-persist -n "$NAMESPACE" || true
-        kubectl get pvc -l app.kubernetes.io/instance=test-persist -n "$NAMESPACE" || true
-        kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' | tail -20 || true
-        return 1
-    fi
-
-    # Debug: Check StatefulSet status immediately after install
-    log_info "StatefulSet status after install:"
-    kubectl get statefulset oxy-test-persist -n "$NAMESPACE" -o wide || true
-    kubectl describe statefulset oxy-test-persist -n "$NAMESPACE" || true
-
-    # Debug: Check PVC status
-    log_info "PVC status after install:"
-    kubectl get pvc -l app.kubernetes.io/instance=test-persist -n "$NAMESPACE" -o wide || true
-
-    # If PVC exists, describe it for more details
-    pvc_name=$(kubectl get pvc -l app.kubernetes.io/instance=test-persist -n "$NAMESPACE" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
-    if [ -n "$pvc_name" ]; then
-        log_info "Describing PVC: $pvc_name"
-        kubectl describe pvc "$pvc_name" -n "$NAMESPACE" || true
-    else
-        log_error "No PVC found for test-persist"
-    fi
-
-    # Debug: Check pod status
-    log_info "Pod status after install:"
-    kubectl get pods -l app.kubernetes.io/instance=test-persist -n "$NAMESPACE" -o wide || true
-
-    # If pod exists, describe it
-    pod_name=$(kubectl get pods -l app.kubernetes.io/instance=test-persist -n "$NAMESPACE" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
-    if [ -n "$pod_name" ]; then
-        log_info "Describing pod: $pod_name"
-        kubectl describe pod "$pod_name" -n "$NAMESPACE" || true
-
-        # Show pod logs if available
-        log_info "Pod logs for: $pod_name"
-        kubectl logs "$pod_name" -n "$NAMESPACE" --tail=50 || true
-    fi
-
-    # Debug: Show recent events
-    log_info "Recent events in namespace:"
-    kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' --field-selector reason!=Pulled,reason!=Created,reason!=Started | tail -10 || true
-
-    # Check StatefulSet pod status before waiting
-    log_info "Checking StatefulSet pod status..."
-    kubectl get statefulset oxy-test-persist -n "$NAMESPACE" -o wide || true
-    kubectl get pods -l app.kubernetes.io/instance=test-persist -n "$NAMESPACE" -o wide || true
-
-    # Check if pod is stuck in Pending due to PVC issues
-    pod_name="oxy-test-persist-0"
-    if kubectl get pod "$pod_name" -n "$NAMESPACE" >/dev/null 2>&1; then
-        pod_phase=$(kubectl get pod "$pod_name" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
-        log_info "StatefulSet pod $pod_name is in phase: $pod_phase"
-
-        if [ "$pod_phase" = "Pending" ]; then
-            log_info "Pod is Pending, checking for scheduling issues:"
-            kubectl describe pod "$pod_name" -n "$NAMESPACE" || true
-            kubectl get events -n "$NAMESPACE" --field-selector involvedObject.name="$pod_name" --sort-by='.lastTimestamp' || true
-        fi
-    fi
-
-    # Wait for StatefulSet to be ready (PVC should bind during pod startup)
-    log_info "Waiting for StatefulSet pod to become ready (PVC should bind automatically)..."
-    if kubectl wait --for=condition=ready pod \
-        -l app.kubernetes.io/instance=test-persist \
-        -n "$NAMESPACE" \
-        --timeout=180s; then
-        log_info "StatefulSet pod is ready!"
-
-        # Verify PVC bound after pod is ready
-        log_info "Verifying PVC status after pod is ready:"
-        kubectl get pvc -l app.kubernetes.io/instance=test-persist -n "$NAMESPACE" -o wide || true
-
-        pvc_status=$(kubectl get pvc -l app.kubernetes.io/instance=test-persist -n "$NAMESPACE" -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "Unknown")
-        if [ "$pvc_status" != "Bound" ]; then
-            log_error "PVC is not bound even though pod is ready. PVC status: $pvc_status"
-            kubectl describe pvc -l app.kubernetes.io/instance=test-persist -n "$NAMESPACE" || true
-            return 1
-        fi
-    else
-        log_error "Timeout waiting for StatefulSet oxy-test-persist"
-
-        # Enhanced debugging on timeout
-        log_info "Final StatefulSet status:"
-        kubectl get statefulset oxy-test-persist -n "$NAMESPACE" -o yaml || true
-
-        log_info "Final pod status:"
-        kubectl get pods -l app.kubernetes.io/instance=test-persist -n "$NAMESPACE" -o yaml || true
-
-        log_info "Final PVC status:"
-        kubectl get pvc -l app.kubernetes.io/instance=test-persist -n "$NAMESPACE" -o yaml || true
-
-        log_info "All events in namespace (last 20):"
-        kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' | tail -20 || true
-
-        return 1
-    fi
-
-    # Verify StatefulSet is used
-    if kubectl get statefulset oxy-test-persist -n "$NAMESPACE" >/dev/null 2>&1; then
-        log_info "StatefulSet created successfully!"
-    else
-        log_error "StatefulSet creation failed!"
-        return 1
-    fi
-
-    # Test data persistence
-    log_info "Testing data persistence..."
-    kubectl exec -n "$NAMESPACE" oxy-test-persist-0 -- sh -c 'echo "test-data" > /workspace/test.txt'
-    if kubectl exec -n "$NAMESPACE" oxy-test-persist-0 -- sh -c 'cat /workspace/test.txt' | grep -q "test-data"; then
-        log_info "Data persistence test passed!"
-    else
-        log_error "Data persistence test failed!"
-        return 1
-    fi
-
-    # Cleanup this test
-    helm uninstall test-persist -n "$NAMESPACE" --wait
-
-    log_info "Persistence deployment test passed!"
-}
-
-test_production_like_deployment() {
-    log_info "Testing production-like deployment..."
-
+test_production() {
+    local ns="${NS_PREFIX}-production"
+    log_info "[production] installing (persistence + ingress + SA + PDB)..."
+    # shellcheck disable=SC2046
     helm install test-production "$CHART_PATH" \
         -f "$CHART_PATH/test-values/production-like-values.yaml" \
-        -n "$NAMESPACE" \
-        --wait --timeout=5m
+        $(shared_db_args db_production) \
+        -n "$ns" --wait --timeout=180s
 
-    # Debug: Check pod and PVC status immediately after install
-    log_info "Checking pod and PVC status after install..."
-    kubectl get pods -l app.kubernetes.io/instance=test-production -n "$NAMESPACE" -o wide || true
-    kubectl get pvc -l app.kubernetes.io/instance=test-production -n "$NAMESPACE" -o wide || true
+    # PVC binds during install --wait; verify it ended up Bound.
+    local pvc_status
+    pvc_status=$(kubectl get pvc -l app.kubernetes.io/instance=test-production -n "$ns" -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+    [[ "$pvc_status" == "Bound" ]] || { log_error "[production] PVC not bound (status: ${pvc_status:-none})"; return 1; }
 
-    # Check if pod is stuck and why
-    pod_name=$(kubectl get pods -l app.kubernetes.io/instance=test-production -n "$NAMESPACE" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
-    if [ -n "$pod_name" ]; then
-        pod_phase=$(kubectl get pod "$pod_name" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
-        log_info "Pod $pod_name is in phase: $pod_phase"
-
-        if [ "$pod_phase" != "Running" ]; then
-            log_info "Pod not running, describing it:"
-            kubectl describe pod "$pod_name" -n "$NAMESPACE" || true
-
-            log_info "Recent events for pod:"
-            kubectl get events -n "$NAMESPACE" --field-selector involvedObject.name="$pod_name" --sort-by='.lastTimestamp' || true
-        fi
+    if ! kubectl get serviceaccount test-production-sa -n "$ns" -o jsonpath='{.metadata.annotations.prometheus\.io/scrape}' | grep -q "true"; then
+        log_error "[production] service account annotation missing"; return 1
     fi
-
-    # Wait for pods to be ready (PVC should bind during this process)
-    log_info "Waiting for pod to become ready (this should trigger PVC binding)..."
-    if kubectl wait --for=condition=ready pod \
-        -l app.kubernetes.io/instance=test-production \
-        -n "$NAMESPACE" \
-        --timeout=180s; then
-        log_info "Pod is ready!"
-
-        # Check PVC status after pod is ready
-        log_info "Checking PVC status after pod is ready:"
-        kubectl get pvc -l app.kubernetes.io/instance=test-production -n "$NAMESPACE" -o wide || true
-
-        # If PVC is still not bound, there's a problem
-        pvc_status=$(kubectl get pvc -l app.kubernetes.io/instance=test-production -n "$NAMESPACE" -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "Unknown")
-        if [ "$pvc_status" != "Bound" ]; then
-            log_error "PVC is not bound even though pod is ready. PVC status: $pvc_status"
-            kubectl describe pvc -l app.kubernetes.io/instance=test-production -n "$NAMESPACE" || true
-            return 1
-        fi
-    else
-        log_error "Pod failed to become ready"
-        # Enhanced debugging for failed pod
-        kubectl get pods -l app.kubernetes.io/instance=test-production -n "$NAMESPACE" -o yaml || true
-        kubectl get pvc -l app.kubernetes.io/instance=test-production -n "$NAMESPACE" -o yaml || true
-        kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' | tail -20 || true
-        return 1
+    if ! kubectl get ingress test-production -n "$ns" -o jsonpath='{.spec.rules[0].host}' | grep -q "test-production.local"; then
+        log_error "[production] ingress host not as expected"; return 1
     fi
-
-    # Verify service account and annotations
-    if kubectl get serviceaccount test-production-sa -n "$NAMESPACE" -o jsonpath='{.metadata.annotations.prometheus\.io/scrape}' | grep -q "true"; then
-        log_info "Service account annotations verified!"
-    else
-        log_error "Service account annotations verification failed!"
-        return 1
-    fi
-
-    # Verify ingress configuration
-    if kubectl get ingress test-production -n "$NAMESPACE" -o jsonpath='{.spec.rules[0].host}' | grep -q "test-production.local"; then
-        log_info "Ingress configuration verified!"
-    else
-        log_error "Ingress configuration failed!"
-        return 1
-    fi
-
-    # Cleanup this test
-    helm uninstall test-production -n "$NAMESPACE" --wait
-
-    log_info "Production-like deployment test passed!"
+    log_info "[production] passed!"
 }
 
-test_upgrade_scenarios() {
-    log_info "Testing helm upgrade scenarios..."
+test_persist() {
+    local ns="${NS_PREFIX}-persist"
+    log_info "[persist] installing..."
+    # shellcheck disable=SC2046
+    helm install test-persist "$CHART_PATH" \
+        -f "$CHART_PATH/test-values/with-persistence-values.yaml" \
+        $(shared_db_args db_persist) \
+        -n "$ns" --wait --timeout=180s
 
-    # Install with default values
+    # Must be a StatefulSet with a Bound PVC.
+    kubectl get statefulset oxy-test-persist -n "$ns" >/dev/null 2>&1 \
+        || { log_error "[persist] StatefulSet missing"; return 1; }
+    local pvc_status
+    pvc_status=$(kubectl get pvc -l app.kubernetes.io/instance=test-persist -n "$ns" -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+    [[ "$pvc_status" == "Bound" ]] || { log_error "[persist] PVC not bound (status: ${pvc_status:-none})"; return 1; }
+
+    # Data survives a write/read round-trip on the mounted volume.
+    kubectl exec -n "$ns" oxy-test-persist-0 -- sh -c 'echo "test-data" > /workspace/test.txt'
+    if kubectl exec -n "$ns" oxy-test-persist-0 -- sh -c 'cat /workspace/test.txt' | grep -q "test-data"; then
+        log_info "[persist] passed!"
+    else
+        log_error "[persist] data persistence check failed"; return 1
+    fi
+}
+
+test_upgrade() {
+    local ns="${NS_PREFIX}-upgrade"
+    local db_args
+    db_args="$(shared_db_args db_upgrade)"
+    log_info "[upgrade] install -> upgrade -> rollback..."
+
+    # shellcheck disable=SC2086
     helm install upgrade-test "$CHART_PATH" \
         -f "$CHART_PATH/test-values/default-values.yaml" \
-        -n "$NAMESPACE" \
-        --wait --timeout=5m
+        $db_args -n "$ns" --wait --timeout=120s
 
-    # Upgrade with ingress enabled
+    # shellcheck disable=SC2086
     helm upgrade upgrade-test "$CHART_PATH" \
         -f "$CHART_PATH/test-values/with-ingress-values.yaml" \
-        -n "$NAMESPACE" \
-        --wait --timeout=5m
+        $db_args -n "$ns" --wait --timeout=120s
 
-    # Verify upgrade worked
-    kubectl wait --for=condition=ready pod \
-        -l app.kubernetes.io/instance=upgrade-test \
-        -n "$NAMESPACE" \
-        --timeout=90s
+    kubectl get ingress -l app.kubernetes.io/instance=upgrade-test -n "$ns" >/dev/null 2>&1 \
+        || { log_error "[upgrade] ingress not created on upgrade"; return 1; }
 
-    kubectl get ingress -l app.kubernetes.io/instance=upgrade-test -n "$NAMESPACE"
+    helm rollback upgrade-test 1 -n "$ns" --wait --timeout=120s
 
-    # Test rollback
-    log_info "Testing rollback..."
-    helm rollback upgrade-test 1 -n "$NAMESPACE" --wait
-    kubectl wait --for=condition=ready pod \
-        -l app.kubernetes.io/instance=upgrade-test \
-        -n "$NAMESPACE" \
-        --timeout=90s
-
-    # Verify ingress is removed after rollback
-    if kubectl get ingress oxy-test-ingress -n "$NAMESPACE" >/dev/null 2>&1; then
-        log_error "Ingress should be removed after rollback!"
-        return 1
+    # Rollback to the ingress-less revision should remove the ingress object.
+    if kubectl get ingress oxy-test-ingress -n "$ns" >/dev/null 2>&1; then
+        log_error "[upgrade] ingress should be removed after rollback"; return 1
     fi
+    log_info "[upgrade] passed!"
+}
 
-    # Cleanup this test
-    helm uninstall upgrade-test -n "$NAMESPACE" --wait
-
-    log_info "Upgrade/rollback test passed!"
+# Run a single named test in its own log file; on failure, append namespace
+# diagnostics to that log so the parallel output stays self-contained.
+run_one() {
+    local name="$1"
+    local ns="${NS_PREFIX}-${name}"
+    local logf="$2"
+    {
+        if "test_${name}"; then
+            echo "__RESULT__ ${name} PASS"
+        else
+            echo "__RESULT__ ${name} FAIL"
+            dump_failure_diagnostics "$ns"
+        fi
+    } >"$logf" 2>&1
 }
 
 run_integration_tests() {
-    log_section "Running Integration Tests"
+    log_section "Running Integration Tests (parallel, max ${MAX_PARALLEL})"
+    setup_shared_infra
 
-    # Check if kubectl is available and we have a cluster
-    if ! command -v kubectl &> /dev/null; then
-        log_error "kubectl not found. Integration tests require kubectl."
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    local pids=() names=() logs=()
+    local running=0
+
+    for name in "${TESTS[@]}"; do
+        # Throttle to MAX_PARALLEL concurrent jobs.
+        while [[ "$running" -ge "$MAX_PARALLEL" ]]; do
+            wait -n 2>/dev/null || true
+            running=$((running - 1))
+        done
+        local logf="${tmpdir}/${name}.log"
+        run_one "$name" "$logf" &
+        pids+=($!); names+=("$name"); logs+=("$logf")
+        running=$((running + 1))
+        log_info "launched: $name"
+    done
+
+    # Wait for the remainder.
+    wait
+
+    # Collect + replay results in deterministic order.
+    local failed=()
+    for i in "${!names[@]}"; do
+        echo ""
+        log_section "Output: ${names[$i]}"
+        cat "${logs[$i]}" || true
+        if grep -q "__RESULT__ ${names[$i]} PASS" "${logs[$i]}" 2>/dev/null; then
+            :
+        else
+            failed+=("${names[$i]}")
+        fi
+    done
+
+    rm -rf "$tmpdir" 2>/dev/null || true
+
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        log_error "Failed tests: ${failed[*]}"
         return 1
     fi
+    log_info "All integration tests passed! 🎉"
+}
 
-    if ! kubectl cluster-info &> /dev/null; then
-        log_error "No Kubernetes cluster available. Please ensure you have access to a cluster."
-        return 1
-    fi
-
-    setup_test_environment
-
-    # Run all integration tests
-    test_default_deployment
-    test_ingress_deployment
-    test_postgres_deployment
-    test_production_like_deployment
-    test_persistence_deployment
-    test_upgrade_scenarios
-
-    local elapsed=$SECONDS
-    log_info "All integration tests passed successfully in ${elapsed}s! 🎉"
+cleanup() {
+    log_info "Cleaning up test namespaces (no --wait; cluster is ephemeral)..."
+    for ns in "${ALL_NAMESPACES[@]}"; do
+        kubectl delete namespace "$ns" --ignore-not-found=true --wait=false 2>/dev/null || true
+    done
 }
 
 main() {
     local cleanup_after=false
-    local verbose=false
-
-    # Parse arguments
     while [[ $# -gt 0 ]]; do
         case $1 in
-            --cleanup)
-                cleanup_after=true
-                shift
-                ;;
-            --verbose)
-                verbose=true
-                set -x
-                shift
-                ;;
-            help|--help|-h)
-                show_usage
-                exit 0
-                ;;
-            *)
-                log_error "Unknown option: $1"
-                show_usage
-                exit 1
-                ;;
+            --cleanup) cleanup_after=true; shift ;;
+            --verbose) set -x; shift ;;
+            help|--help|-h) show_usage; exit 0 ;;
+            *) log_error "Unknown option: $1"; show_usage; exit 1 ;;
         esac
     done
 
-    # Set cleanup trap if requested
-    if [[ "$cleanup_after" == "true" ]]; then
-        trap cleanup EXIT
-    fi
-
-    # Quietly reference verbose to satisfy linters if unused later
-    if [[ "$verbose" == "true" ]]; then :; fi
+    [[ "$cleanup_after" == "true" ]] && trap cleanup EXIT
 
     log_section "Oxy-App Helm Chart Integration Testing"
-    log_info "Cleanup after: $cleanup_after"
+    log_info "Cleanup after: $cleanup_after | Max parallel: $MAX_PARALLEL"
 
     check_prerequisites
-
     run_integration_tests
 
     log_info "🎉 Integration tests completed successfully!"
 }
 
-# Run main function with all arguments
 main "$@"


### PR DESCRIPTION
## Why

The integration suite (`scripts/test.sh`) ran six releases **serially in one namespace**, each spinning up its own postgres StatefulSet + PVC and tearing it down with `helm uninstall --wait` (5-min default). On a flaky-storage runner every test ate a ~5-min teardown tail and the whole suite hit **36 min** (run 27461694135). Baseline on a healthy runner was ~6.5 min.

## What changed

- **One shared postgres** (Deployment + Service, `emptyDir`, no PVC) started once; **one database per test** so parallel tests never race on migrations.
- Each test runs in **its own namespace**, in a **bounded parallel pool** (`MAX_PARALLEL=3`).
- App points at the shared DB via `env.OXY_DATABASE_URL` with the postgres subchart disabled — which also strips the `wait-for-postgres` init container.
- **No `helm uninstall --wait`**; namespaces are dropped with `--wait=false` (kind cluster is ephemeral).
- **Tight explicit timeouts** everywhere so storage flakiness fails fast instead of burning the 5-min helm default.
- Dropped the dedicated `postgres` test (every test now exercises postgres — it was pure duplication).

## Validation

Full suite on a local kind cluster: **~2m38s** end-to-end (vs ~6.5 min baseline). CI is the real check on runner hardware.

No chart/template changes — only `scripts/test.sh`.