### PR TITLE
fix(oxy-app): ideRoutes must list flat git routes (0.6.3)

### DIFF
--- a/charts/oxy-app/Chart.yaml
+++ b/charts/oxy-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oxy-app
 description: A Helm chart for Oxy application deployment on kubernetes
 type: application
-version: 0.6.2
+version: 0.6.3
 appVersion: "0.5.49"
 keywords:
   - oxy

--- a/charts/oxy-app/values.yaml
+++ b/charts/oxy-app/values.yaml
@@ -628,16 +628,37 @@ ideRoutes:
   # manifest but lands on ide here; harmless.
   - path: /api/*/compile
   - path: /api/*/compile/*
-  # Working-copy git operations.
-  - path: /api/*/git
-  - path: /api/*/git/*
-  # Workspace onboarding subtree (clones + scaffolds).
+  # Working-copy git operations. These are mounted FLAT in the router
+  # (no `/git/` segment), so each must be listed explicitly — must stay
+  # in lock-step with IDE_ONLY_PATTERNS in
+  # crates/app/src/server/role_manifest.rs (build_git_routes). A
+  # `/api/*/git/*` wildcard would match NONE of them.
+  - path: /api/*/branches
+  - path: /api/*/branches/*
+  - path: /api/*/switch-branch
+  - path: /api/*/pull-changes
+  - path: /api/*/fetch
+  - path: /api/*/push-changes
+  - path: /api/*/force-push
+  - path: /api/*/discard-all
+  - path: /api/*/abort-rebase
+  - path: /api/*/continue-rebase
+  - path: /api/*/resolve-conflict-file
+  - path: /api/*/unresolve-conflict-file
+  - path: /api/*/resolve-conflict-with-content
+  - path: /api/*/reset-to-commit
+  - path: /api/*/recent-commits
+  - path: /api/*/revision-info
+  # Data repositories — git checkouts under modeling/ (build_data_repo_routes).
+  - path: /api/*/repositories
+  - path: /api/*/repositories/*
+  # Workspace onboarding subtree (clones + scaffolds), incl. the flat
+  # onboarding-readiness route (reads config.yml from the working copy).
   - path: /api/*/onboarding
   - path: /api/*/onboarding/*
+  - path: /api/*/onboarding-readiness
   # Modeling / Airform dbt projects live on disk.
   - path: /api/*/modeling/*
-  # Branch switch — moves HEAD on the working copy.
-  - path: /api/*/switch-branch
   # Org-scoped workspace creation (clones the repo into a new workspace).
   - path: /api/orgs/*/onboarding/demo
   - path: /api/orgs/*/onboarding/new


### PR DESCRIPTION
## Problem

The `ideRoutes` default routed `/api/*/git` + `/api/*/git/*` to the StatefulSet, but the backend mounts git operations **flat** — there is no `/git/` path segment. The real routes are `/api/{ws}/pull-changes`, `/push-changes`, `/fetch`, `/force-push`, `/discard-all`, `/branches`, `/branches/*`, `/reset-to-commit`, `/recent-commits`, `/revision-info`, and the rebase/conflict routes. The wildcard matched **none** of them.

Consequence: with inverse routing enabled, every IDE git operation falls through to the catch-all → the stateless serve fleet → **500** (no working copy on disk). This is the exact failure the routing split exists to prevent.

The same gap existed in the backend role manifest and is fixed in lock-step in oxygen-internal#2520 (`role_manifest.rs`, with a drift-guard test).

## Fix

- Replace the ghost `/api/*/git[/*]` patterns with the real flat git routes.
- Add the data-repo subtree `/api/*/repositories[/*]` (git checkouts under `modeling/`).
- Add the flat `/api/*/onboarding-readiness` route (reads `config.yml` from the working copy).
- Bump chart `0.6.2 → 0.6.3`.

## Render verification

`helm template` with `serveFleet.enabled: true`:
- 32 ingress rules total.
- catch-all `/` → serve fleet.
- `/api/*/pull-changes`, `/api/*/push-changes`, `/api/*/repositories`, `/api/*/onboarding-readiness`, etc. → StatefulSet.

## Sync contract

These entries MUST mirror `IDE_ONLY_PATTERNS` in `crates/app/src/server/role_manifest.rs` (`build_git_routes` / `build_data_repo_routes`). oxygen-internal#2520 adds a backend test (`manifest_covers_every_git_route`) that fails if a git route is added without a manifest entry; this ingress list still needs manual sync (tracked as a follow-up — no in-repo cross-check across the two repos yet).